### PR TITLE
changed uav policy email parameter to be a list.

### DIFF
--- a/compliance/tags/tag_checker/tag_checker.pt
+++ b/compliance/tags/tag_checker/tag_checker.pt
@@ -43,7 +43,7 @@ end
 
 parameter "param_email" do
   category "Contact"
-  label "Email addresses (separate with commas)"
+  label "Email addresses"
   type "list"
 end
 

--- a/cost/volumes/uav_policy.pt
+++ b/cost/volumes/uav_policy.pt
@@ -5,7 +5,9 @@
 
 name "Unattached Volumes"
 rs_pt_ver 20180301
+type "policy"
 short_description "Finds unattached volumes older than specified number of days and, optionally, deletes them."
+long_description "Version: 1.1"
 severity "medium"
 category "Cost"
 

--- a/cost/volumes/uav_policy.pt
+++ b/cost/volumes/uav_policy.pt
@@ -2,11 +2,10 @@
 #
 # This policy reports unattached volumes older than a user-specified age, and optionally deletes the volumes.
 #
+
 name "Unattached Volumes"
 rs_pt_ver 20180301
-type "policy"
 short_description "Finds unattached volumes older than specified number of days and, optionally, deletes them."
-long_description "Version: 1.1"
 severity "medium"
 category "Cost"
 
@@ -16,11 +15,8 @@ permission "general_permissions" do
 end
 
 parameter "param_email" do
-  type "string"
-  label "Email address to send escalation emails to"
-  allowed_pattern /[a-zA-Z0-9_\-\.]+@[a-zA-Z0-9_\-\.]/
-  min_length 1
-  constraint_description "Must be an email address."
+  type "list"
+  label "List of emails address(es) to receive reports."
 end
 
 parameter "param_days_old" do


### PR DESCRIPTION
changed tag checker email parameter label to remove mention of comma
separated

### Description

Fixes UAV policy to support email list.
Cleaned up tag policy to remove mention of providing emails as a comma separated list.

### Issues Resolved

Support for email lists.

### Contribution Check List

- [X ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
