### PR TITLE
PHX-781 Optimize JavaScript and datasources for Security Group Rules without Descriptions policy

### DIFF
--- a/security/security_groups/rules_without_descriptions/CHANGELOG.md
+++ b/security/security_groups/rules_without_descriptions/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.2
+----
+- Optimized JavaScript so it actually runs in a reasonable amount of time
+
 v1.1
 ----
 - Updating email from string to list

--- a/security/security_groups/rules_without_descriptions/security_group_rules_without_descriptions.pt
+++ b/security/security_groups/rules_without_descriptions/security_group_rules_without_descriptions.pt
@@ -25,6 +25,11 @@ resources "security_groups", type: "rs_cm.security_groups" do
   cloud_href href(iter_item)
 end
 
+resources "security_group_rules", type: "rs_cm.security_group_rules" do
+  iterate @security_groups
+  security_group_href href(iter_item)
+end
+
 resources "networks", type: "rs_cm.networks"
 
 datasource "ds_security_groups" do
@@ -32,7 +37,7 @@ datasource "ds_security_groups" do
   field "resource_uid", val(iter_item,  "resource_uid")
   field "name", val(iter_item, "name")
   field "href", href(iter_item)
-  field "links", val(iter_item, "links")
+  field "network_href", jmes_path(iter_item, "links[?rel=='network'].href | [0]")
 end
 
 datasource "ds_networks" do
@@ -43,13 +48,11 @@ end
 
 datasource "ds_security_group_rules" do
   iterate @security_groups
-  request do
-    auth $auth_rs
-    verb "GET"
-    host rs_cm_host
-    path join([href(iter_item),"/security_group_rules"])
-    header "X-Api-Version", "1.5"
-  end
+  field "href", href(iter_item)
+  field "protocol", from(iter_item)
+  field "source_type", from(iter_item)
+  field "description", from(iter_item)
+  field "security_group_href", jmes_path(iter_item, "links[?rel=='security_group'].href | [0]")
 end
 
 datasource "ds_munged_security_groups" do
@@ -60,47 +63,41 @@ script "js_munge_sec_group", type: "javascript" do
   parameters "ds_security_groups", "ds_security_group_rules", "ds_networks", "rs_project_id", "rs_cm_host"
   result "groups_and_rules"
 code <<-EOS
+var security_groups = {};
+
+for (var index = 0; index < ds_security_groups.length; index++) {
+  var security_group = ds_security_groups[index];
+  security_groups[security_group.href] = security_group;
+}
+
+var networks = {};
+
+for (var index = 0; index < ds_networks.length; index++) {
+  var network = ds_security_groups[index];
+  networks[network.href] = network;
+}
+
 var groups_and_rules=[];
 var base_url="https://" + rs_cm_host + "/acct/"
-for ( var i = 0; i < ds_security_group_rules.length; i++) {
-  for ( var s = 0; s < ds_security_groups.length; s++) {
-    for ( var h = 0; h < ds_security_group_rules[i]["links"].length; h++) {
-      if ( ds_security_group_rules[i]["links"][h]["href"] == ds_security_groups[s]["href"] ){
-        ds_security_group_rules[i]["security_group_name"] = ds_security_groups[s]["name"]
-        ds_security_group_rules[i]["security_group_href"] = ds_security_groups[s]["href"]
-        for ( var l=0; l < ds_security_groups[s]["links"].length; l++ ){
-          if ( ds_security_groups[s]["links"][l]["rel"] == "network" ) {
-            ds_security_group_rules[i]["network_href"] = ds_security_groups[s]["links"][l]["href"]
-          }
-        }
-      } else if (ds_security_group_rules[i]["links"][h]["rel"] == "self") {
-        ds_security_group_rules[i]["self_href"] = ds_security_group_rules[i]["links"][h]["href"]
-      }
-    }
-    for ( var n = 0; n < ds_networks.length; n++ ){
-      if ( ds_security_group_rules[i]["network_href"] == ds_networks[n]["href"] ){
-        ds_security_group_rules[i]["network_name"] = ds_networks[n]["name"]
-        var network_res=ds_networks[n]["href"].split('/')
-        var sg_res=ds_security_group_rules[i]["security_group_href"].split('/')
-        ds_security_group_rules[i]["security_group_access_link_root"] = base_url.concat(rs_project_id,'/network_manager#networks/',network_res[3],'/security_groups/',sg_res[5])
-      }
-    }
-  }
-  groups_and_rules.push(
-    {
-      security_group_name: ds_security_group_rules[i]["security_group_name"],
-      security_group_href: ds_security_group_rules[i]["security_group_href"],
-      href: ds_security_group_rules[i]["self_href"],
-      protocol: ds_security_group_rules[i]["protocol"],
-      source_type: ds_security_group_rules[i]["source_type"],
-      description: ds_security_group_rules[i]["description"],
-      network_href: ds_security_group_rules[i]["network_href"],
-      network_name: ds_security_group_rules[i]["network_name"],
-      security_group_access_link_root: ds_security_group_rules[i]["security_group_access_link_root"]
-    }
-  )
-};
 
+for (var index = 0; index < ds_security_group_rules.length; index++) {
+  var security_group_rule = ds_security_group_rules[index];
+  var security_group = security_groups[security_group_rule.security_group_href];
+  var network = networks[security_group.network_href];
+  var security_group_access_link_root = base_url.concat(rs_project_id, '/network_manager#networks/', network.href.split('/')[3], '/security_groups/', security_group.href.split('/')[5]);
+
+  groups_and_rules.push({
+    security_group_name: security_group.name,
+    security_group_href: security_group.href,
+    href: security_group_rule.href,
+    protocol: security_group_rule.protocol,
+    source_type: security_group_rule.source_type,
+    description: security_group_rule.description,
+    network_href: network.href,
+    network_name: network.name,
+    security_group_access_link_root: security_group_access_link_root
+  });
+}
 EOS
 end
 

--- a/security/security_groups/rules_without_descriptions/security_group_rules_without_descriptions.pt
+++ b/security/security_groups/rules_without_descriptions/security_group_rules_without_descriptions.pt
@@ -47,7 +47,7 @@ datasource "ds_networks" do
 end
 
 datasource "ds_security_group_rules" do
-  iterate @security_groups
+  iterate @security_group_rules
   field "href", href(iter_item)
   field "protocol", from(iter_item)
   field "source_type", from(iter_item)
@@ -73,7 +73,7 @@ for (var index = 0; index < ds_security_groups.length; index++) {
 var networks = {};
 
 for (var index = 0; index < ds_networks.length; index++) {
-  var network = ds_security_groups[index];
+  var network = ds_networks[index];
   networks[network.href] = network;
 }
 
@@ -84,7 +84,11 @@ for (var index = 0; index < ds_security_group_rules.length; index++) {
   var security_group_rule = ds_security_group_rules[index];
   var security_group = security_groups[security_group_rule.security_group_href];
   var network = networks[security_group.network_href];
-  var security_group_access_link_root = base_url.concat(rs_project_id, '/network_manager#networks/', network.href.split('/')[3], '/security_groups/', security_group.href.split('/')[5]);
+  if (network) {
+    var security_group_access_link_root = base_url.concat(rs_project_id, '/network_manager#networks/', network.href.split('/')[3], '/security_groups/', security_group.href.split('/')[5]);
+  } else {
+    network = {};
+  }
 
   groups_and_rules.push({
     security_group_name: security_group.name,

--- a/security/security_groups/rules_without_descriptions/security_group_rules_without_descriptions.pt
+++ b/security/security_groups/rules_without_descriptions/security_group_rules_without_descriptions.pt
@@ -2,7 +2,7 @@ name "Security Group Rules without Descriptions"
 rs_pt_ver 20180301
 type "policy"
 short_description "A policy that sends email notifications when a security group has no description"
-long_description "Version 1.1"
+long_description "Version 1.2"
 severity "high"
 category "Security"
 


### PR DESCRIPTION
### Description

This makes the JavaScript for the `Security Group Rules without Descriptions` policy template execute in less than a second rather than in some unreasonable time over 5 minutes by populating maps of the security groups and networks by their HREFs instead of exhaustively search 

### Issues Resolved

This resolves JavaScript timing out for the `Security Group Rules without Descriptions` policy template.

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
