### PR TITLE
Downsize Policy: Specify working clouds

### DIFF
--- a/active-policy-list.json
+++ b/active-policy-list.json
@@ -28,7 +28,7 @@
     {
       "name": "Downsize Instances Policy Template",
       "file_name": "cost/downsize_instance/downsize-instance.pt",
-      "version": "1.2"
+      "version": "1.4"
     },
     {
       "name": "Old Snapshots Policy",

--- a/cost/downsize_instance/CHANGELOG.md
+++ b/cost/downsize_instance/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.4
+----
+- Filtering to only look at clouds represented in instance_types.json
+
 v1.3
 ----
 - Adding in downsize actions

--- a/cost/downsize_instance/CHANGELOG.md
+++ b/cost/downsize_instance/CHANGELOG.md
@@ -1,6 +1,7 @@
 v1.4
 ----
-- Filtering to only look at clouds represented in instance_types.json
+- Filtering to only look at clouds represented in instance_types.json.
+- Added current instance type to the output report.
 
 v1.3
 ----

--- a/cost/downsize_instance/downsize-instance.pt
+++ b/cost/downsize_instance/downsize-instance.pt
@@ -360,10 +360,10 @@ policy "policy_rightsize" do
     detail_template <<-EOS
 # Instances that can be downsized
 
-| Account | Instance Name | Resource UID | Average Memory | Free Average Memory | Total Average Memory | Max Free Memory | Max Total Memory | Max CPU Idle | Average CPU Idle | New Instance Size |
-| ------- | ------------- | ------------ | -------------- | ------------------- | -------------------- | --------------- | ---------------- | ------------ | ---------------- | ------------------ |
+| Account | Instance Name | Resource UID | Average Memory | Free Average Memory | Total Average Memory | Max Free Memory | Max Total Memory | Max CPU Idle | Average CPU Idle | Current Instance Size | New Instance Size |
+| ------- | ------------- | ------------ | -------------- | ------------------- | -------------------- | --------------- | ---------------- | ------------ | ---------------- | --------------------- | ----------------- |
 {{ range data -}}
-| {{rs_project_name}} | {{.name}} | {{.resource_uid}} | {{.average_mem_percent}}% | {{.free_avg }}MB | {{.total_avg }}MB | {{.max_free_memory }}MB | {{.max_total_memory }}MB | {{.max_cpu_idle}}% | {{.average_cpu_idle}}% | {{.next_instance_size}} |
+  | {{rs_project_name}} | {{.name}} | {{.resource_uid}} | {{.average_mem_percent}}% | {{.free_avg }}MB | {{.total_avg }}MB | {{.max_free_memory }}MB | {{.max_total_memory }}MB | {{.max_cpu_idle}}% | {{.average_cpu_idle}}% | {{.instance_type}} | {{.next_instance_size}} |
 {{ end -}}
 
 EOS

--- a/cost/downsize_instance/downsize-instance.pt
+++ b/cost/downsize_instance/downsize-instance.pt
@@ -2,7 +2,7 @@ name "Downsize Instances Policy Template"
 rs_pt_ver 20180301
 type "policy"
 short_description "A policy that downsizes instances based on monitoring metrics. See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/downsize_instance) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.2"
+long_description "Version: 1.4"
 severity "medium"
 category "Cost"
 
@@ -76,7 +76,11 @@ end
 
 auth "auth_rs", type: "rightscale"
 
-resources "clouds", type: "rs_cm.clouds"
+resources "clouds", type: "rs_cm.clouds" do
+  filter do # ignore clouds that are NOT represented in instance_types.json
+    cloud_type ne: ["vscale", "soft_layer", "cloud_stack", "rackspace_next_gen", "blue_skies","open_stack_v2","uca","open_stack_v3"]
+  end
+end
 
 resources "instances", type: "rs_cm.instances" do
   iterate @clouds  


### PR DESCRIPTION
### Description

Fixes a bug described in issue 59

### Issues Resolved

The root cause was that accounts with clouds other than AWS, Google, Azure would have issues because the instance types (e.g. "small" in a VMware env) are not found in instance_types.json.
Change the @clouds datasource to only include AWS, Google and Azure.

Also added the current instance type to the output report so that a user can see what instance type is being used currently.


### Contribution Check List

- [X ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ X] New functionality has been documented in CHANGELOG.MD
