### PR TITLE
Make Dangerfile actually valid

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -7,7 +7,7 @@ has_new_policy_template = git.added_files.select{ |file| file.end_with? "pt" }
 # Changelog entries are required for changes to library files.
 no_changelog_entry = (changed_files.grep(/[\w]+CHANGELOG.md/i)+changed_files.grep(/CHANGELOG.md/i)).empty?
 if (has_app_changes.length != 0) && no_changelog_entry
-  raise "Please add a changelog"
+  fail "Please add a changelog"
 end
 
 missing_doc_changes = (changed_files.grep(/[\w]+README.md/i)+changed_files.grep(/README.md/i)).empty?
@@ -16,9 +16,9 @@ if (has_app_changes.length != 0) && missing_doc_changes
 end
 
 if (has_new_policy_template.length != 0) && missing_doc_changes
-  raise "A README.md is required for new templates"
+  fail "A README.md is required for new templates"
 end
 
-raise 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
+fail 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
 
-raise 'Please add labels to this Pull Request' if github.pr_labels.empty?
+fail 'Please add labels to this Pull Request' if github.pr_labels.empty?


### PR DESCRIPTION
### Description

Make the Dangerfile actually use `fail` instead of `raise` so it doesn't complain that it is invalid.

### Issues Resolved

None

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
