### PR TITLE
Tag example needs to use semi-colons instead of colons

### DIFF
--- a/cost/schedule_instances/README.md
+++ b/cost/schedule_instances/README.md
@@ -14,7 +14,7 @@ Start and Stop hours are 24 hour format: for example 8-17 is start at 8am, and s
 Days of the week: SU,MO,TU,WE,TH,FR,SA
 Timezone: Use the TZ designator from the timezone list.  For Eastern time use America/New_York
 
-Example: instance:schedule=8-17:MO,TU,WE,TH,FR:America/New_York. Stops instances at 5pm, starts instance at 8am, Monday - Friday, Eastern Time.  
+Example: instance:schedule=8-17;MO,TU,WE,TH,FR;America/New_York. Stops instances at 5pm, starts instance at 8am, Monday - Friday, Eastern Time.  
 
 Instances are off during the weekend and start back up on Monday morning and are off at 5p every weekday.
 Times are UTC unless the Timezone field is provided.


### PR DESCRIPTION
### Description

The README for the schedule instances policy shows colons between the time and days and days and timezone fields in the tag.
These need to be changed to semi-colons .

### Issues Resolved

None

### Contribution Check List

- [X ] All tests pass.
- [ ] New functionality includes testing.
- [X ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
