### PR TITLE
Psasset 793 old key deactivation enhancement

### DIFF
--- a/active-policy-list.json
+++ b/active-policy-list.json
@@ -48,7 +48,7 @@
     {
       "name": "AWS Cloud Credentials Rotation",
       "file_name": "operational/cloud_credentials/aws/aws_connection_key_rotation_policy.pt",
-      "version": "1.2"
+      "version": "1.4"
     },
     {
       "name": "No Recent Snapshots",

--- a/operational/cloud_credentials/aws/README.md
+++ b/operational/cloud_credentials/aws/README.md
@@ -10,6 +10,7 @@ When applied, the policy updates the credentials immediately and then updates th
 This policy performs the following actions:
 - Create a new set of security credentials in AWS for the IAM user account connected to RightScale.
 - Update the RightScale AWS cloud connections to use the new keys.
+- Deactivate the previously used IAM key.
 - Update RightScale Credentials, AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY with the new IAM user keys.
 
 ### Caveats and Prerequisites

--- a/operational/cloud_credentials/aws/aws_connection_key_rotation_policy.pt
+++ b/operational/cloud_credentials/aws/aws_connection_key_rotation_policy.pt
@@ -2,7 +2,7 @@ name "AWS Cloud Credentials Rotation"
 rs_pt_ver 20180301
 type "policy"
 short_description "Updates the IAM user keys used to connect RightScale to an AWS account. See the [README](https://github.com/rightscale/policy_templates/tree/master/operational/cloud_credentials/aws) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.3"
+long_description "Version: 1.4"
 severity "medium"
 category "Operational"
 

--- a/operational/cloud_credentials/aws/aws_connection_key_rotation_policy.pt
+++ b/operational/cloud_credentials/aws/aws_connection_key_rotation_policy.pt
@@ -165,6 +165,10 @@ define update_aws_connection($data, $param_rotation_period) do
     end
   end
   
+  # Now deactivate the old key that was being used.
+  # The key is deactivated instead of deleted to allow for a potential rollback use-case.
+  call deactivate_aws_key(cred("AWS_ACCESS_KEY_ID"))
+  
   # Now update the credentials in RightScale to reflect the new keys
   call update_cred("AWS_ACCESS_KEY_ID", $new_access_key_id)
   call update_cred("AWS_SECRET_ACCESS_KEY", $new_secret_access_key)
@@ -287,6 +291,16 @@ end
 define delete_aws_key($access_key_id) do
   call log("AWS Key Rotation Policy: Deleting the following key to make room for a new set of keys: "+$access_key_id, "")
   $iam_api = "https://iam.amazonaws.com/?Version=2010-05-08&Action=DeleteAccessKey&AccessKeyId="+$access_key_id
+  $response = http_get(    
+    url: $iam_api,
+    "signature": { type: "aws" }
+    )
+end
+
+# Deactivate an AWS access key
+define deactivate_aws_key($access_key_id) do
+  call log("AWS Key Rotation Policy: Deactivating the following key: "+$access_key_id, "")
+  $iam_api = "https://iam.amazonaws.com/?Version=2010-05-08&Status=Inactive&Action=UpdateAccessKey&AccessKeyId="+$access_key_id
   $response = http_get(    
     url: $iam_api,
     "signature": { type: "aws" }

--- a/operational/cloud_credentials/aws/changelog.md
+++ b/operational/cloud_credentials/aws/changelog.md
@@ -1,3 +1,7 @@
+v1.4
+----
+- Added logic to deactivate the previously used key.
+
 v1.3
 ----
 - Fixed typo in call to "log()" definition.


### PR DESCRIPTION
### Description

Once the policy switches over to use the newly generated keys, it now deactivates the previously used key.

### Issues Resolved

Feedback from customer drove this change.

### Contribution Check List

- [ X] All tests pass.
- [ X] New functionality includes testing.
- [ X] New functionality has been documented in the README if applicable
- [ X] New functionality has been documented in CHANGELOG.MD
