### PR TITLE
Issue 126 uav delete error handling

### DIFF
--- a/cost/volumes/unattached_volumes/CHANGELOG.md
+++ b/cost/volumes/unattached_volumes/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.7
+----
+- Improved handling of volume delete failures. If a delete volume action is not allowed, say, due to the volume being locked, the volume will be tagged with the cloud exception error message and the policy will continue on to the next volume in the list.
+
 v1.6
 ----
 - Show volume tags in incident report.

--- a/cost/volumes/unattached_volumes/README.md
+++ b/cost/volumes/unattached_volumes/README.md
@@ -4,6 +4,9 @@
 
 This Policy Template scans all volumes in the given account and identifies any unattached volumes that have been unattached for at least the number of user-specified days. If any are found, an incident report will show the volumes, and related information and an email will be sent to the user-specified email address.
 
+If the user specifies that the volumes should be deleted, the policy will delete the volumes. 
+If the volume is not able to be deleted, say, due to it being locked, the volume will be tagged to indicate the CloudException error that was received.
+
 Optionally, the user can specify one or more RightScale tags that if found on a volume will exclude the volume from the list.
 Additionally, the user can optionally specify if the aged volumes should be deleted by the policy.
 

--- a/cost/volumes/unattached_volumes/uav_policy.pt
+++ b/cost/volumes/unattached_volumes/uav_policy.pt
@@ -115,6 +115,7 @@ for (var i = 0; i < ds_clouds.length; i++) {
   var cloud_name = ds_cloud["name"]
   cloud_hash[cloud_href] = { "cloud_type": cloud_type, "cloud_name": cloud_name }
 }
+
 // Build a pg hash that is pg resource id -> { pg type, pg name }
 var pg_hash = {}
 for (var i = 0; i < ds_pgs.length; i++) {
@@ -127,6 +128,8 @@ for (var i = 0; i < ds_pgs.length; i++) {
   }
   pg_hash[pg_id] = { "name": pg_name, "account_type": pg_account_type }
 }
+
+
 
 // loop through the volumes and find the unattached ones and deduce storage type if Azure
 for (var i = 0; i < ds_volumes.length; i++) {
@@ -198,7 +201,7 @@ for (var i = 0; i < ds_volumes.length; i++) {
       // old Azure - we also care
       my_vol["azure_disk_type"] = "Unmanaged"
       my_vol["azure_storage_type"] = "Classic"
-      my_vol["azure_storage_account_name"] = pg_hash[my_vol["pg_id"]]["name"]
+      my_vol["azure_storage_account_name"] = pg_hash[my_vol["pg_id"]]["name"]  // name stuff
     } else {
       // Other clouds - we do not care
       my_vol["azure_disk_type"] = "N/A"

--- a/cost/volumes/unattached_volumes/uav_policy.pt
+++ b/cost/volumes/unattached_volumes/uav_policy.pt
@@ -121,7 +121,10 @@ var pg_hash = {}
 for (var i = 0; i < ds_pgs.length; i++) {
   var ds_pg = ds_pgs[i]
   var pg_id = ds_pg["id"]
-  var pg_name = ds_pg["name"]
+  var pg_name = "unknown"
+  if (ds_pg["name"]) {
+    pg_name = ds_pg["name"]
+  }
   var pg_account_type = "unspecified"
   if (ds_pg["account_type"]) { 
     pg_account_type = ds_pg["account_type"]
@@ -201,7 +204,13 @@ for (var i = 0; i < ds_volumes.length; i++) {
       // old Azure - we also care
       my_vol["azure_disk_type"] = "Unmanaged"
       my_vol["azure_storage_type"] = "Classic"
-      my_vol["azure_storage_account_name"] = pg_hash[my_vol["pg_id"]]["name"]  // name stuff
+      my_vol["azure_storage_account_name"] = "Unknown"
+      if (my_vol["pg_id"]) {
+        var vol_pg_id = my_vol["pg_id"]
+        if (pg_hash[vol_pg_id]) {
+          my_vol["azure_storage_account_name"] = pg_hash[vol_pg_id]["name"] 
+        }
+      }
     } else {
       // Other clouds - we do not care
       my_vol["azure_disk_type"] = "N/A"

--- a/cost/volumes/unattached_volumes/uav_policy.pt
+++ b/cost/volumes/unattached_volumes/uav_policy.pt
@@ -2,7 +2,7 @@ name "Unattached Volumes"
 rs_pt_ver 20180301
 type "policy"
 short_description "Finds unattached volumes older than specified number of days and, optionally, deletes them. See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/volumes/unattached_volumes) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.6"
+long_description "Version: 1.7"
 severity "medium"
 category "Cost"
 
@@ -139,8 +139,8 @@ for (var i = 0; i < ds_volumes.length; i++) {
     my_vol["size"] = vol["size"]
     my_vol["iops"] = vol["iops"]
     my_vol["status"] = vol["status"]
-    if (param_delete == "Email and Delete") {  // Then the volume is marked that it was deleted.
-      my_vol["status"] = "DELETED"
+    if (param_delete == "Email and Delete") {  // Then the volume is marked so that it will be deleted later
+      my_vol["action"] = "DELETE"
     }
     my_vol["created_at"] =  vol["created_at"]
     my_vol["updated_at"] =  vol["updated_at"]
@@ -262,11 +262,30 @@ end
 
 define delete_volumes($data) do
   foreach $item in $data do
-    if $item["status"] == "DELETED"
-      # Find the volume
-      @volume = rs_cm.get(href: $item["href"])
-      # Delete the volume 
-      delete(@volume)
+    if $item["action"] == "DELETE"
+      # If the delete fails, tag the volume with some info about the failure
+      sub on_error: handle_delete_failure(@volume) do
+        # Find the volume
+        @volume = rs_cm.get(href: $item["href"])
+        # Delete the volume 
+        delete(@volume)
+      end
     end
   end
+end
+
+define handle_delete_failure(@volume) do
+  $_error_behavior = "skip"
+  $msg = split($_error["message"], "\n")
+  foreach $item in $msg do
+    if $item =~ "CloudException"
+      $tag = "uav_policy:error="+$item
+      rs_cm.tags.multi_add(tags: [$tag], resource_hrefs: [@volume.href])
+    end
+  end
+end
+
+# create an audit entry 
+define log($summary, $details) do
+  rs_cm.audit_entries.create(notify: "None", audit_entry: { auditee_href: @@account, summary: $summary , detail: $details})
 end


### PR DESCRIPTION
### Description

This fixes a problem where the policy would fail out if it encountered an error when deleting a volume.
Now the policy tags the volume with the CloudException error if there is one and skips to the next volume in the list to delete.
It also shows the actual volume status instead of overwriting it with "DELETED"

### Issues Resolved

https://github.com/rightscale/policy_templates/issues/126

### Contribution Check List

- [ X] All tests pass.
- [ X] New functionality includes testing.
- [X ] New functionality has been documented in the README if applicable
- [ X] New functionality has been documented in CHANGELOG.MD
