### PR TITLE
Issue 126 uav delete error handling

### DIFF
--- a/cost/volumes/unattached_volumes/CHANGELOG.md
+++ b/cost/volumes/unattached_volumes/CHANGELOG.md
@@ -1,6 +1,7 @@
 v1.7
 ----
 - Improved handling of volume delete failures. If a delete volume action is not allowed, say, due to the volume being locked, the volume will be tagged with the cloud exception error message and the policy will continue on to the next volume in the list.
+- Subsequent runs of the applied policy will retry the delete (if that option was selected).
 
 v1.6
 ----

--- a/cost/volumes/unattached_volumes/CHANGELOG.md
+++ b/cost/volumes/unattached_volumes/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.7
+----
+- Improved handling of volume delete failures. If a delete volume action is not allowed, say, due to the volume being locked, the volume will be tagged with the cloud exception error message and the policy will continue on to the next volume in the list.
+
 v1.6
 ----
 - Show volume tags in incident report.

--- a/cost/volumes/unattached_volumes/README.md
+++ b/cost/volumes/unattached_volumes/README.md
@@ -6,6 +6,8 @@ This Policy Template scans all volumes in the given account and identifies any u
 
 If the user specifies that the volumes should be deleted, the policy will delete the volumes. 
 If the volume is not able to be deleted, say, due to it being locked, the volume will be tagged to indicate the CloudException error that was received.
+If the issue causing the delete failure is removed, the next run of the policy will delete the volume. 
+Note: The unattached volumes report will reflect the updated set of unattached volumes on the subsequent run.
 
 Optionally, the user can specify one or more RightScale tags that if found on a volume will exclude the volume from the list.
 Additionally, the user can optionally specify if the aged volumes should be deleted by the policy.

--- a/cost/volumes/unattached_volumes/README.md
+++ b/cost/volumes/unattached_volumes/README.md
@@ -4,6 +4,9 @@
 
 This Policy Template scans all volumes in the given account and identifies any unattached volumes that have been unattached for at least the number of user-specified days. If any are found, an incident report will show the volumes, and related information and an email will be sent to the user-specified email address.
 
+If the user specifies that the volumes should be deleted, the policy will delete the volumes. 
+If the volume is not able to be deleted, say, due to it being locked, the volume will be tagged to indicate the CloudException error that was received.
+
 Optionally, the user can specify one or more RightScale tags that if found on a volume will exclude the volume from the list.
 Additionally, the user can optionally specify if the aged volumes should be deleted by the policy.
 

--- a/cost/volumes/unattached_volumes/uav_policy.pt
+++ b/cost/volumes/unattached_volumes/uav_policy.pt
@@ -115,6 +115,7 @@ for (var i = 0; i < ds_clouds.length; i++) {
   var cloud_name = ds_cloud["name"]
   cloud_hash[cloud_href] = { "cloud_type": cloud_type, "cloud_name": cloud_name }
 }
+
 // Build a pg hash that is pg resource id -> { pg type, pg name }
 var pg_hash = {}
 for (var i = 0; i < ds_pgs.length; i++) {
@@ -127,6 +128,8 @@ for (var i = 0; i < ds_pgs.length; i++) {
   }
   pg_hash[pg_id] = { "name": pg_name, "account_type": pg_account_type }
 }
+
+
 
 // loop through the volumes and find the unattached ones and deduce storage type if Azure
 for (var i = 0; i < ds_volumes.length; i++) {
@@ -198,7 +201,7 @@ for (var i = 0; i < ds_volumes.length; i++) {
       // old Azure - we also care
       my_vol["azure_disk_type"] = "Unmanaged"
       my_vol["azure_storage_type"] = "Classic"
-      my_vol["azure_storage_account_name"] = pg_hash[my_vol["pg_id"]]["name"]
+      my_vol["azure_storage_account_name"] = pg_hash[my_vol["pg_id"]]["name"]  // name stuff
     } else {
       // Other clouds - we do not care
       my_vol["azure_disk_type"] = "N/A"

--- a/cost/volumes/unattached_volumes/uav_policy.pt
+++ b/cost/volumes/unattached_volumes/uav_policy.pt
@@ -87,7 +87,6 @@ end
 datasource "ds_unattached_volumes" do
   run_script $js_unattached_volumes, $ds_clouds, $ds_pgs, $ds_volumes, $param_delete #, $ds_resource_tags_hash
 end
-
 # Find unattached volumes.
 # If Azure volume, deduce the type.
 # Calculate the volume's age.
@@ -131,8 +130,6 @@ for (var i = 0; i < ds_pgs.length; i++) {
   }
   pg_hash[pg_id] = { "name": pg_name, "account_type": pg_account_type }
 }
-
-
 
 // loop through the volumes and find the unattached ones and deduce storage type if Azure
 for (var i = 0; i < ds_volumes.length; i++) {
@@ -241,6 +238,26 @@ for (var i = 0; i < ds_volumes.length; i++) {
 }
 EOS
 end
+
+# This is a copy of $ds_unattached_volumes but with a current timestamp added.
+# This is leveraged in the policy declaration to force an escalation action to try and delete the volumes (if that option was selected by the user).
+# This way if a volume was not deleted on the last run due to something like it being locked or snapshots existing and then someone removed the lock or snapshots,
+# the subsequent run will try to delete the volumes again and be successful.
+# The run after that will then report the new list of volumes that still exist.
+datasource "ds_unattached_volumes_with_timestamp" do
+  run_script $js_unattached_volumes_with_timestamp, $ds_unattached_volumes
+end
+
+script "js_unattached_volumes_with_timestamp", type: "javascript" do
+  parameters "ds_unattached_volumes"
+  result "unattached_volumes_with_timestamp"
+  code <<-EOS
+// This is the eventual output list of unattached volumes.
+var unattached_volumes_with_timestamp = ds_unattached_volumes;
+
+for (var i = 0; i < unattached_volumes_with_timestamp.length; i++) {
+  unattached_volumes_with_timestamp["timestamp"] = 
+}
 
 policy "pol_unattached_volumes" do
   validate_each $ds_unattached_volumes do

--- a/cost/volumes/unattached_volumes/uav_policy.pt
+++ b/cost/volumes/unattached_volumes/uav_policy.pt
@@ -121,7 +121,10 @@ var pg_hash = {}
 for (var i = 0; i < ds_pgs.length; i++) {
   var ds_pg = ds_pgs[i]
   var pg_id = ds_pg["id"]
-  var pg_name = ds_pg["name"]
+  var pg_name = "unknown"
+  if (ds_pg["name"]) {
+    pg_name = ds_pg["name"]
+  }
   var pg_account_type = "unspecified"
   if (ds_pg["account_type"]) { 
     pg_account_type = ds_pg["account_type"]
@@ -201,7 +204,13 @@ for (var i = 0; i < ds_volumes.length; i++) {
       // old Azure - we also care
       my_vol["azure_disk_type"] = "Unmanaged"
       my_vol["azure_storage_type"] = "Classic"
-      my_vol["azure_storage_account_name"] = pg_hash[my_vol["pg_id"]]["name"]  // name stuff
+      my_vol["azure_storage_account_name"] = "Unknown"
+      if (my_vol["pg_id"]) {
+        var vol_pg_id = my_vol["pg_id"]
+        if (pg_hash[vol_pg_id]) {
+          my_vol["azure_storage_account_name"] = pg_hash[vol_pg_id]["name"] 
+        }
+      }
     } else {
       // Other clouds - we do not care
       my_vol["azure_disk_type"] = "N/A"

--- a/cost/volumes/unattached_volumes/uav_policy.pt
+++ b/cost/volumes/unattached_volumes/uav_policy.pt
@@ -338,8 +338,3 @@ define handle_delete_failure(@volume) do
     end
   end
 end
-
-# create an audit entry 
-define log($summary, $details) do
-  rs_cm.audit_entries.create(notify: "None", audit_entry: { auditee_href: @@account, summary: $summary , detail: $details})
-end

--- a/cost/volumes/unattached_volumes/uav_policy.pt
+++ b/cost/volumes/unattached_volumes/uav_policy.pt
@@ -2,7 +2,7 @@ name "Unattached Volumes"
 rs_pt_ver 20180301
 type "policy"
 short_description "Finds unattached volumes older than specified number of days and, optionally, deletes them. See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/volumes/unattached_volumes) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.6"
+long_description "Version: 1.7"
 severity "medium"
 category "Cost"
 
@@ -139,8 +139,8 @@ for (var i = 0; i < ds_volumes.length; i++) {
     my_vol["size"] = vol["size"]
     my_vol["iops"] = vol["iops"]
     my_vol["status"] = vol["status"]
-    if (param_delete == "Email and Delete") {  // Then the volume is marked that it was deleted.
-      my_vol["status"] = "DELETED"
+    if (param_delete == "Email and Delete") {  // Then the volume is marked so that it will be deleted later
+      my_vol["action"] = "DELETE"
     }
     my_vol["created_at"] =  vol["created_at"]
     my_vol["updated_at"] =  vol["updated_at"]
@@ -262,11 +262,30 @@ end
 
 define delete_volumes($data) do
   foreach $item in $data do
-    if $item["status"] == "DELETED"
-      # Find the volume
-      @volume = rs_cm.get(href: $item["href"])
-      # Delete the volume 
-      delete(@volume)
+    if $item["action"] == "DELETE"
+      # If the delete fails, tag the volume with some info about the failure
+      sub on_error: handle_delete_failure(@volume) do
+        # Find the volume
+        @volume = rs_cm.get(href: $item["href"])
+        # Delete the volume 
+        delete(@volume)
+      end
     end
   end
+end
+
+define handle_delete_failure(@volume) do
+  $_error_behavior = "skip"
+  $msg = split($_error["message"], "\n")
+  foreach $item in $msg do
+    if $item =~ "CloudException"
+      $tag = "uav_policy:error="+$item
+      rs_cm.tags.multi_add(tags: [$tag], resource_hrefs: [@volume.href])
+    end
+  end
+end
+
+# create an audit entry 
+define log($summary, $details) do
+  rs_cm.audit_entries.create(notify: "None", audit_entry: { auditee_href: @@account, summary: $summary , detail: $details})
 end

--- a/cost/volumes/unattached_volumes/uav_policy.pt
+++ b/cost/volumes/unattached_volumes/uav_policy.pt
@@ -247,30 +247,36 @@ end
 datasource "ds_unattached_volumes_with_timestamp" do
   run_script $js_unattached_volumes_with_timestamp, $ds_unattached_volumes
 end
-
 script "js_unattached_volumes_with_timestamp", type: "javascript" do
   parameters "ds_unattached_volumes"
   result "unattached_volumes_with_timestamp"
   code <<-EOS
 // This is the eventual output list of unattached volumes.
-var unattached_volumes_with_timestamp = ds_unattached_volumes;
+var unattached_volumes_with_timestamp = [];
 
-for (var i = 0; i < unattached_volumes_with_timestamp.length; i++) {
-  unattached_volumes_with_timestamp["timestamp"] = 
+for (var i = 0; i < ds_unattached_volumes.length; i++) {
+  unattached_volumes_with_timestamp[i] = ds_unattached_volumes[i]
+  unattached_volumes_with_timestamp[i]["timestamp"] = new Date()
 }
+EOS
+end
 
 policy "pol_unattached_volumes" do
+  
+  # REPORT UNATTACHED VOLUMES OLDER THAN GIVEN NUMBER OF DAYS
+  # This first validation produces the report and related email.
+  # It goes through the unattached volumes that were found by the script-based datasource above
+  # and checks if not older than specified number of days.
   validate_each $ds_unattached_volumes do
-	# Go through the unattached volumes that were found by the script-based datasource above
-	# and check if not older than specified number of days.
-	# If the check fails, it'll flag the volume
-	check le(val(item, "age"), $param_days_old)
 
-	escalate $process_unattached_volumes
+  	check le(val(item, "age"), $param_days_old)
+  
+  	# Send email report
+  	escalate $send_email_report 
+  
+  	summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Unattached Volumes Found"
 
-	summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Unattached Volumes Found"
-
-  detail_template <<-EOS
+  	detail_template <<-EOS
 The following {{ len data }} unattached volumes, for Account: {{ rs_project_name }} (ID: {{ rs_project_id }}), have exceeded the specified age of: {{ parameters.param_days_old }} days old\n
 | Cloud Name | Volume Name | Age (days) | Volume Type | Resource UID | Size (GBs) | Status | IOPS | Azure Disk Type | Azure Storage Type | Azure Storage Account | Created At | Updated At | Tags | Volume HREF |
 | ---------- | ----------- | -----------| ----------- | ------------ | ---------- | ------ | ---- | --------------- | ------------------ | --------------------- | ---------- | ---------- | ---- | ----------- |
@@ -280,15 +286,34 @@ The following {{ len data }} unattached volumes, for Account: {{ rs_project_name
 EOS
 
   end
-end
 
+  # TAKE ACTION ON UNATTACHED VOLUMES
+  # This validation is focused on going through the unattached volumes and deleting them if the user selected that option.
+  # It uses a data source that is identical to the one used for the REPORT validation above but this datasource includes a timestamp.
+  # This timestamp changes each time the policy is run and so forces a validation.
+  # This way if a delete of a volume failed the last time the policy ran, this will force another attempt on this run.
+  validate_each $ds_unattached_volumes_with_timestamp do
 
-escalation "process_unattached_volumes" do
-  email $param_email
+  	check le(val(item, "age"), $param_days_old)
   
-  run "delete_volumes", data
+  	# Delete the volume if user selected the delete option
+  	escalate $process_volumes
+ 	
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): Processing {{ len data }} unattached volumes"
+    detail_template "Processing volumes ...."
+  end
 end
 
+escalation "send_email_report" do
+  email $param_email
+end
+  
+escalation "process_volumes" do
+  run "delete_volumes", data
+  # remove the "Processing volumes" incident since it's a done deal at this point.
+  resolve_incident
+end
+  
 define delete_volumes($data) do
   foreach $item in $data do
     if $item["action"] == "DELETE"


### PR DESCRIPTION
### Description
Handles error when deleting volumes.
Now if a volume can't be deleted (e.g. it has a lock on it), the volume is tagged with the cloudexception error if applicable and then moves on to the next volume.
The applied policy will try to delete volumes each time it is run so that if the issue causing the deletion failure is removed, the policy will delete the volume on the next scheduled or on-demand run.

### Issues Resolved

https://github.com/rightscale/policy_templates/issues/126

### Contribution Check List

- [X ] All tests pass.
- [X ] New functionality includes testing.
- [ X] New functionality has been documented in the README if applicable
- [ X] New functionality has been documented in CHANGELOG.MD
