### PR TITLE
Update js to skip servers without monitoring data

### DIFF
--- a/cost/downsize_instance/CHANGELOG.md
+++ b/cost/downsize_instance/CHANGELOG.md
@@ -1,6 +1,7 @@
 v1.10
 ----
 - Added cpu and memory datapoint check for instances that are operational, but not sending monitoring data back to the platform.
+
 v1.9
 ----
 - Changed total memory calculation to use instance_type memory attribute.

--- a/cost/downsize_instance/CHANGELOG.md
+++ b/cost/downsize_instance/CHANGELOG.md
@@ -1,3 +1,6 @@
+v1.10
+----
+- Added cpu and memory datapoint check for instances that are operational, but not sending monitoring data back to the platform.
 v1.9
 ----
 - Changed total memory calculation to use instance_type memory attribute.

--- a/cost/downsize_instance/README.md
+++ b/cost/downsize_instance/README.md
@@ -10,7 +10,7 @@ There are two policy templates required to support this policy, `Downsize Instan
 The Downsize Instances Policy Template is used to actually downsize instances. If you chose `Email` from the `Escalation Options`, it will only email you which instances can be downsized.
 If you chose `Downsize And Email` from the `Escalation Options`, it will email you a list of servers that were downsized and the size to which were changed. This policy will also resize the instance. This required the instance to be **stopped**.
 If a server is marked `N/A`, no action will be taken and only the resize tag will be removed. You will need to manually move that instance to another family type.
-**_This policy requires [RightLink 10](http://docs.rightscale.com/rl10/getting_started.html) and monitoring to be enabled_**, see [Installation](http://docs.rightscale.com/rl10/about.html)
+**_This policy requires [RightLink 10](http://docs.rightscale.com/rl10/getting_started.html) with monitoring enabled and collecting metrics_**, see [Installation](http://docs.rightscale.com/rl10/about.html)
 
 
 ### Parameters

--- a/cost/downsize_instance/downsize-instance.pt
+++ b/cost/downsize_instance/downsize-instance.pt
@@ -382,10 +382,10 @@ policy "policy_rightsize" do
     detail_template <<-EOS
 # {{ len data }} Instances can be downsized
 
-| Account ID | Instance Name | Resource UID | Average Memory | Free Average Memory | Total Average Memory | Max Free Memory | Max Total Memory | Max CPU Idle | Average CPU Idle | Current Instance Size | New Instance Size |
+| Instance Name | Resource UID | Average Memory | Free Average Memory | Total Average Memory | Max Free Memory | Max Total Memory | Max CPU Idle | Average CPU Idle | Current Instance Size | New Instance Size |
 | ------- | ------------- | ------------ | -------------- | ------------------- | -------------------- | --------------- | ---------------- | ------------ | ---------------- | --------------------- | ----------------- |
 {{ range data -}}
-  | {{ rs_project_id }} | {{.name}} | {{.resource_uid}} | {{.average_mem_percent}}% | {{.free_avg }}MB | {{.total_avg }}MB | {{.max_free_memory }}MB | {{.max_total_memory }}MB | {{.max_cpu_idle}}% | {{.average_cpu_idle}}% | {{.instance_type}} | {{.next_instance_size}} |
+  | {{.name}} | {{.resource_uid}} | {{.average_mem_percent}}% | {{.free_avg }}MB | {{.total_avg }}MB | {{.max_free_memory }}MB | {{.max_total_memory }}MB | {{.max_cpu_idle}}% | {{.average_cpu_idle}}% | {{.instance_type}} | {{.next_instance_size}} |
 {{ end -}}
 
 EOS

--- a/cost/downsize_instance/downsize-instance.pt
+++ b/cost/downsize_instance/downsize-instance.pt
@@ -2,7 +2,7 @@ name "Downsize Instances based on CPU and Memory"
 rs_pt_ver 20180301
 type "policy"
 short_description "A policy that downsizes instances based on monitoring metrics. See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/downsize_instance) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.9"
+long_description "Version: 1.10"
 severity "medium"
 category "Cost"
 

--- a/cost/downsize_instance/downsize-instance.pt
+++ b/cost/downsize_instance/downsize-instance.pt
@@ -1,4 +1,4 @@
-name "Downsize Instances based on CPU and Memory Update"
+name "Downsize Instances based on CPU and Memory"
 rs_pt_ver 20180301
 type "policy"
 short_description "A policy that downsizes instances based on monitoring metrics. See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/downsize_instance) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."

--- a/cost/downsize_instance/downsize-instance.pt
+++ b/cost/downsize_instance/downsize-instance.pt
@@ -267,6 +267,10 @@ var calculated_instances = [];
 for (var i = 0; i < instance_metrics_free_memory.length; i++) {
       var free_sum = 0;
       free_memory_data_points = instance_metrics_free_memory[i]["memory_data_points"]
+      //skip if no memory data point are available
+      if (free_memory_data_points < 1 ) {
+        continue;
+      }
       var free_avg = free_memory_data_points.reduce(function(acc, val) { return acc + val; })/free_memory_data_points.length;
       max_free_memory = Math.max.apply(Math,free_memory_data_points)
 
@@ -300,6 +304,10 @@ for ( var i = 0; i < calculated_instances.length; i++ ) {
   for ( v = 0; v < instance_metrics_cpu.length; v++ ) {
     if ( calculated_instances[i]["href"] == instance_metrics_cpu[v]["href"] ) {
       cpu_data_points = instance_metrics_cpu[v]["data_points"]
+      //skip if no cpu data points are available
+      if (cpu_data_points < 1 ) {
+        continue;
+      }
       var max_cpu_idle = 0;
       var average_cpu_idle = 0;
       max_cpu_idle = Math.max.apply(Math,cpu_data_points)

--- a/cost/downsize_instance/downsize-instance.pt
+++ b/cost/downsize_instance/downsize-instance.pt
@@ -1,4 +1,4 @@
-name "Downsize Instances based on CPU and Memory"
+name "Downsize Instances based on CPU and Memory Update"
 rs_pt_ver 20180301
 type "policy"
 short_description "A policy that downsizes instances based on monitoring metrics. See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/downsize_instance) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
@@ -382,10 +382,10 @@ policy "policy_rightsize" do
     detail_template <<-EOS
 # {{ len data }} Instances can be downsized
 
-| Account | Instance Name | Resource UID | Average Memory | Free Average Memory | Total Average Memory | Max Free Memory | Max Total Memory | Max CPU Idle | Average CPU Idle | Current Instance Size | New Instance Size |
+| Account ID | Instance Name | Resource UID | Average Memory | Free Average Memory | Total Average Memory | Max Free Memory | Max Total Memory | Max CPU Idle | Average CPU Idle | Current Instance Size | New Instance Size |
 | ------- | ------------- | ------------ | -------------- | ------------------- | -------------------- | --------------- | ---------------- | ------------ | ---------------- | --------------------- | ----------------- |
 {{ range data -}}
-  | {{rs_project_name}} | {{.name}} | {{.resource_uid}} | {{.average_mem_percent}}% | {{.free_avg }}MB | {{.total_avg }}MB | {{.max_free_memory }}MB | {{.max_total_memory }}MB | {{.max_cpu_idle}}% | {{.average_cpu_idle}}% | {{.instance_type}} | {{.next_instance_size}} |
+  | {{ rs_project_id }} | {{.name}} | {{.resource_uid}} | {{.average_mem_percent}}% | {{.free_avg }}MB | {{.total_avg }}MB | {{.max_free_memory }}MB | {{.max_total_memory }}MB | {{.max_cpu_idle}}% | {{.average_cpu_idle}}% | {{.instance_type}} | {{.next_instance_size}} |
 {{ end -}}
 
 EOS


### PR DESCRIPTION
### Description

Skips any operational vm that is not sending cpu or memory monitoring data back to the platform.

### Issues Resolved

https://github.com/rightscale/policy_templates/issues/151

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] New functionality has been documented in CHANGELOG.MD
