### PR TITLE
Repo Maintenance: Add Travis commit message to docs build

### DIFF
--- a/tools/travis/build_docs.sh
+++ b/tools/travis/build_docs.sh
@@ -1,6 +1,7 @@
 body='{
   "request": {
-  "branch":"master"
+    "branch":"master",
+    "message": "Build triggered by rightscale/policy_templates"
 }}'
 
 curl -s -X POST \


### PR DESCRIPTION
### Description

These changes add a commit message to the build of rightscale/docs on merge to master.

### Issues Resolved

N/A

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
