### PR TITLE
Pol 34 AWS delete unused ELB(CLB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Please contact sales@rightscale.com to learn more.
 - [Azure Reserved Instance Utilization](./cost/azure/reserved_instances/utilization/)
 - [Billing Center Cost Anomaly](./cost/billing_center_cost_anomaly/)
 - [Google Committed Use Discount (CUD) Report](./cost/google/cud_report/)
+- [AWS Delete Unused Elastic Load Balancers (CLB)](./cost/aws/elb/clb_unused/)
 
 ### Security
 - [Security Group: ICMP Enabled](./security/security_groups/icmp_enabled/)

--- a/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
+++ b/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
@@ -108,6 +108,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
 	
   result "content"
   code <<-EOS
+  var param_exclude_tags_lower=param_exclude_tags.toString().toLowerCase().split(',');
   var content=[]
   for(var i=0; i<ds_aws_clb_list_tags.length; i++){
     clb=ds_aws_clb_list_tags[i]
@@ -134,7 +135,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
     var tagKeyValue=""
     for(var j=0; j < tags.length; j++){
       tag = tags[j]
-      if(((param_exclude_tags.join()+',').toLowerCase()).indexOf((tag['tagKey']+'='+tag['tagValue']+',').toLowerCase()) !== -1){
+      if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
         isTagMatched = true;
       }
       // Constructing tags with comma separated to display in detail_template

--- a/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
+++ b/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
@@ -7,6 +7,15 @@ category "Cost"
 severity "low"
 
 ###############################################################################
+# Permissions
+###############################################################################
+
+permission "perm_read_creds" do
+  actions   "rs_cm.show_sensitive","rs_cm.index_sensitive"
+  resources "rs_cm.credentials"
+end
+
+###############################################################################
 # User inputs
 ###############################################################################
 
@@ -197,13 +206,13 @@ end
 
 policy "policy_delete_unused_CLB" do
   validate $ds_unused_clb_map do
-    summary_template "List of Unused Classic Load Balancers in AWS"
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Unused Classic Load Balancers Found in AWS"
     detail_template <<-EOS
 ## List of Unused Classic Load Balancers
-| Organization Name | LoadBalancer_Name | Instance_ID | Availability_Zones | TAG_Value |
-| ----------------- | ------------------ | ------------ | ----------------- | --------- |
+| LoadBalancer_Name | Instance_ID | Availability_Zones | TAG_Value |
+| ----------------- | ----------- | ------------------ | --------- |
 {{ range data -}}
-| {{rs_org_name}} | {{ .loadBalancerName }} | {{ .instanceId }} | {{ .availabilityZones }} | {{.tagKeyValue}} |
+| {{ .loadBalancerName }} | {{ .instanceId }} | {{ .availabilityZones }} | {{.tagKeyValue}} |
 {{ end -}}
 ###### Policy Applied in Account: {{ rs_project_name }} (Account ID: {{ rs_project_id }}) within Org: {{ rs_org_name }} (Org ID: {{ rs_org_id }})
 EOS

--- a/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
+++ b/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
@@ -1,7 +1,7 @@
 name "AWS Delete Unused Classic Load Balancers"
 rs_pt_ver 20180301
 type "policy"
-short_description "Report and remediate any Classic Load Balancers(CLB) that are not currently in use. \n See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/aws/elb/clb_unused) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
+short_description "Report and remediate any Classic Load Balancers (CLB) that are not currently in use. \n See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/aws/elb/clb_unused) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
 long_description "Version: 1.0"
 category "Cost"
 severity "low"

--- a/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
+++ b/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
@@ -34,11 +34,132 @@ end
 # Authentication
 ###############################################################################
 
-auth "aws", type: "aws" do
-  version "4"
+auth "auth_us_east_1", type: "aws" do
+  version 4
   service "elasticloadbalancing"
-  access_key cred("AWS_ACCESS_KEY_ID")
-  secret_key cred("AWS_SECRET_ACCESS_KEY")
+  region 'us-east-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_us_east_2", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'us-east-2'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_us_west_1", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'us-west-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_us_west_2", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'us-west-2'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_ap_south_1", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'ap-south-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_ap_northeast_2", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'ap-northeast-2'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_ap_southeast_1", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'ap-southeast-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_ap_southeast_2", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'ap-southeast-2'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_ap_northeast_1", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'ap-northeast-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_ca_central_1", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'ca-central-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_eu_central_1", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'eu-central-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_eu_west_1", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'eu-west-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_eu_west_2", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'eu-west-2'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_eu_west_3", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'eu-west-3'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_sa_east_1", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'sa-east-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_eu_north_1", type: "aws" do
+  version 4
+  service "elasticloadbalancing"
+  region 'eu-north-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
 end
 
 ###############################################################################
@@ -46,10 +167,310 @@ end
 ###############################################################################
 
 #https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html
-datasource "ds_aws_clb_list" do
+datasource "ds_us_east_1_clb_list" do
   request do
-    auth $aws
-    host "elasticloadbalancing.amazonaws.com"
+    auth $auth_us_east_1
+    host "elasticloadbalancing.us-east-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_us_east_2_clb_list" do
+  request do
+    auth $auth_us_east_2
+    host "elasticloadbalancing.us-east-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_us_west_1_clb_list" do
+  request do
+    auth $auth_us_west_1
+    host "elasticloadbalancing.us-west-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_us_west_2_clb_list" do
+  request do
+    auth $auth_us_west_2
+    host "elasticloadbalancing.us-west-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_ap_south_1_clb_list" do
+  request do
+    auth $auth_ap_south_1
+    host "elasticloadbalancing.ap-south-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_ap_northeast_2_clb_list" do
+  request do
+    auth $auth_ap_northeast_2
+    host "elasticloadbalancing.ap-northeast-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_ap_southeast_1_clb_list" do
+  request do
+    auth $auth_ap_southeast_1
+    host "elasticloadbalancing.ap-southeast-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_ap_southeast_2_clb_list" do
+  request do
+    auth $auth_ap_southeast_2
+    host "elasticloadbalancing.ap-southeast-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_ap_northeast_1_clb_list" do
+  request do
+    auth $auth_ap_northeast_1
+    host "elasticloadbalancing.ap-northeast-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_ca_central_1_clb_list" do
+  request do
+    auth $auth_ca_central_1
+    host "elasticloadbalancing.ca-central-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_eu_central_1_clb_list" do
+  request do
+    auth $auth_eu_central_1
+    host "elasticloadbalancing.eu-central-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_eu_west_1_clb_list" do
+  request do
+    auth $auth_eu_west_1
+    host "elasticloadbalancing.eu-west-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_eu_west_2_clb_list" do
+  request do
+    auth $auth_eu_west_2
+    host "elasticloadbalancing.eu-west-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_eu_west_3_clb_list" do
+  request do
+    auth $auth_eu_west_3
+    host "elasticloadbalancing.eu-west-3.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_sa_east_1_clb_list" do
+  request do
+    auth $auth_sa_east_1
+    host "elasticloadbalancing.sa-east-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
+  end
+end
+
+datasource "ds_eu_north_1_clb_list" do
+  request do
+    auth $auth_eu_north_1
+    host "elasticloadbalancing.eu-north-1.amazonaws.com"
     path "/"
     verb "GET"
     query "Action", "DescribeLoadBalancers"
@@ -67,11 +488,431 @@ datasource "ds_aws_clb_list" do
 end
 
 #https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeTags.html
-datasource "ds_aws_clb_list_tags" do
-  iterate $ds_aws_clb_list
+datasource "ds_us_east_1_clb_list_tags" do
+  iterate $ds_us_east_1_clb_list
   request do
-    auth $aws
-    host "elasticloadbalancing.amazonaws.com"
+    auth $auth_us_east_1
+    host "elasticloadbalancing.us-east-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_us_east_2_clb_list_tags" do
+  iterate $ds_us_east_2_clb_list
+  request do
+    auth $auth_us_east_2
+    host "elasticloadbalancing.us-east-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_us_west_1_clb_list_tags" do
+  iterate $ds_us_west_1_clb_list
+  request do
+    auth $auth_us_west_1
+    host "elasticloadbalancing.us-west-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_us_west_2_clb_list_tags" do
+  iterate $ds_us_west_2_clb_list
+  request do
+    auth $auth_us_west_2
+    host "elasticloadbalancing.us-west-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_ap_south_1_clb_list_tags" do
+  iterate $ds_ap_south_1_clb_list
+  request do
+    auth $auth_ap_south_1
+    host "elasticloadbalancing.ap-south-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_ap_northeast_2_clb_list_tags" do
+  iterate $ds_ap_northeast_2_clb_list
+  request do
+    auth $auth_ap_northeast_2
+    host "elasticloadbalancing.ap-northeast-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_ap_southeast_1_clb_list_tags" do
+  iterate $ds_ap_southeast_1_clb_list
+  request do
+    auth $auth_ap_southeast_1
+    host "elasticloadbalancing.ap-southeast-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_ap_southeast_2_clb_list_tags" do
+  iterate $ds_ap_southeast_2_clb_list
+  request do
+    auth $auth_ap_southeast_2
+    host "elasticloadbalancing.ap-southeast-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_ap_northeast_1_clb_list_tags" do
+  iterate $ds_ap_northeast_1_clb_list
+  request do
+    auth $auth_ap_northeast_1
+    host "elasticloadbalancing.ap-northeast-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_ca_central_1_clb_list_tags" do
+  iterate $ds_ca_central_1_clb_list
+  request do
+    auth $auth_ca_central_1
+    host "elasticloadbalancing.ca-central-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_eu_central_1_clb_list_tags" do
+  iterate $ds_eu_central_1_clb_list
+  request do
+    auth $auth_eu_central_1
+    host "elasticloadbalancing.eu-central-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_eu_west_1_clb_list_tags" do
+  iterate $ds_eu_west_1_clb_list
+  request do
+    auth $auth_eu_west_1
+    host "elasticloadbalancing.eu-west-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_eu_west_2_clb_list_tags" do
+  iterate $ds_eu_west_2_clb_list
+  request do
+    auth $auth_eu_west_2
+    host "elasticloadbalancing.eu-west-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_eu_west_3_clb_list_tags" do
+  iterate $ds_eu_west_3_clb_list
+  request do
+    auth $auth_eu_west_3
+    host "elasticloadbalancing.eu-west-3.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_sa_east_1_clb_list_tags" do
+  iterate $ds_sa_east_1_clb_list
+  request do
+    auth $auth_sa_east_1
+    host "elasticloadbalancing.sa-east-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
+    end
+  end
+end
+
+datasource "ds_eu_north_1_clb_list_tags" do
+  iterate $ds_eu_north_1_clb_list
+  request do
+    auth $auth_eu_north_1
+    host "elasticloadbalancing.eu-north-1.amazonaws.com"
     path "/"
     verb "GET"
     query "Action", "DescribeTags"
@@ -96,11 +937,356 @@ datasource "ds_aws_clb_list_tags" do
 end
 
 #https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeInstanceHealth.html
-datasource "ds_aws_instances_health" do
-  iterate $ds_aws_clb_list
+datasource "ds_us_east_1_instances_health" do
+  iterate $ds_us_east_1_clb_list
+   request do
+    auth $auth_us_east_1
+    host "elasticloadbalancing.us-east-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_us_east_2_instances_health" do
+  iterate $ds_us_east_2_clb_list
   request do
-    auth $aws
-    host "elasticloadbalancing.amazonaws.com"
+    auth $auth_us_east_2
+    host "elasticloadbalancing.us-east-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_us_west_1_instances_health" do
+  iterate $ds_us_west_1_clb_list
+  request do
+    auth $auth_us_west_1
+    host "elasticloadbalancing.us-west-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_us_west_2_instances_health" do
+  iterate $ds_us_west_2_clb_list
+  request do
+    auth $auth_us_west_2
+    host "elasticloadbalancing.us-west-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_ap_south_1_instances_health" do
+  iterate $ds_ap_south_1_clb_list
+  request do
+    auth $auth_ap_south_1
+    host "elasticloadbalancing.ap-south-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_ap_northeast_2_instances_health" do
+  iterate $ds_ap_northeast_2_clb_list
+  request do
+    auth $auth_ap_northeast_2
+    host "elasticloadbalancing.ap-northeast-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_ap_southeast_1_instances_health" do
+  iterate $ds_ap_southeast_1_clb_list
+  request do
+    auth $auth_ap_southeast_1
+    host "elasticloadbalancing.ap-southeast-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_ap_southeast_2_instances_health" do
+  iterate $ds_ap_southeast_2_clb_list
+  request do
+    auth $auth_ap_southeast_2
+    host "elasticloadbalancing.ap-southeast-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_ap_northeast_1_instances_health" do
+  iterate $ds_ap_northeast_1_clb_list
+  request do
+    auth $auth_ap_northeast_1
+    host "elasticloadbalancing.ap-northeast-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_ca_central_1_instances_health" do
+  iterate $ds_ca_central_1_clb_list
+  request do
+    auth $auth_ca_central_1
+    host "elasticloadbalancing.ca-central-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_eu_central_1_instances_health" do
+  iterate $ds_eu_central_1_clb_list
+  request do
+    auth $auth_eu_central_1
+    host "elasticloadbalancing.eu-central-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_eu_west_1_instances_health" do
+  iterate $ds_eu_west_1_clb_list
+  request do
+    auth $auth_eu_west_1
+    host "elasticloadbalancing.eu-west-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_eu_west_2_instances_health" do
+  iterate $ds_eu_west_2_clb_list
+  request do
+    auth $auth_eu_west_2
+    host "elasticloadbalancing.eu-west-2.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_eu_west_3_instances_health" do
+  iterate $ds_eu_west_3_clb_list
+  request do
+    auth $auth_eu_west_3
+    host "elasticloadbalancing.eu-west-3.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_sa_east_1_instances_health" do
+  iterate $ds_sa_east_1_clb_list
+  request do
+    auth $auth_sa_east_1
+    host "elasticloadbalancing.sa-east-1.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+datasource "ds_eu_north_1_instances_health" do
+  iterate $ds_eu_north_1_clb_list
+  request do
+    auth $auth_eu_north_1
+    host "elasticloadbalancing.eu-north-1.amazonaws.com"
     path "/"
     verb "GET"
     query "Action", "DescribeInstanceHealth"
@@ -120,7 +1306,7 @@ datasource "ds_aws_instances_health" do
 end
 
 datasource "ds_unused_clb_map" do
-  run_script $js_aws_clb_filter_map, $ds_aws_clb_list_tags, $ds_aws_instances_health, $param_exclude_tags
+  run_script $js_aws_clb_filter_map, $ds_us_east_1_clb_list_tags, $ds_us_east_2_clb_list_tags, $ds_us_west_1_clb_list_tags, $ds_us_west_2_clb_list_tags, $ds_ap_south_1_clb_list_tags, $ds_ap_northeast_2_clb_list_tags, $ds_ap_southeast_1_clb_list_tags, $ds_ap_southeast_2_clb_list_tags, $ds_ap_northeast_1_clb_list_tags, $ds_ca_central_1_clb_list_tags, $ds_eu_central_1_clb_list_tags, $ds_eu_west_1_clb_list_tags, $ds_eu_west_2_clb_list_tags, $ds_eu_west_3_clb_list_tags, $ds_sa_east_1_clb_list_tags, $ds_eu_north_1_clb_list_tags, $ds_us_east_1_instances_health, $ds_us_east_2_instances_health, $ds_us_west_1_instances_health, $ds_us_west_2_instances_health, $ds_ap_south_1_instances_health, $ds_ap_northeast_2_instances_health, $ds_ap_southeast_1_instances_health, $ds_ap_southeast_2_instances_health, $ds_ap_northeast_1_instances_health, $ds_ca_central_1_instances_health, $ds_eu_central_1_instances_health, $ds_eu_west_1_instances_health, $ds_eu_west_2_instances_health, $ds_eu_west_3_instances_health, $ds_sa_east_1_instances_health, $ds_eu_north_1_instances_health, $param_exclude_tags
 end
 
 ###############################################################################
@@ -129,7 +1315,7 @@ end
 
 #https://www.cloudconformity.com/conformity-rules/ELB/unused-elastic-load-balancers.html
 script "js_aws_clb_filter_map", type: "javascript" do
-  parameters "ds_aws_clb_list_tags", "ds_aws_instances_health", "param_exclude_tags"
+  parameters "ds_us_east_1_clb_list_tags","ds_us_east_2_clb_list_tags","ds_us_west_1_clb_list_tags","ds_us_west_2_clb_list_tags","ds_ap_south_1_clb_list_tags","ds_ap_northeast_2_clb_list_tags","ds_ap_southeast_1_clb_list_tags","ds_ap_southeast_2_clb_list_tags","ds_ap_northeast_1_clb_list_tags","ds_ca_central_1_clb_list_tags","ds_eu_central_1_clb_list_tags","ds_eu_west_1_clb_list_tags","ds_eu_west_2_clb_list_tags","ds_eu_west_3_clb_list_tags","ds_sa_east_1_clb_list_tags","ds_eu_north_1_clb_list_tags","ds_us_east_1_instances_health","ds_us_east_2_instances_health","ds_us_west_1_instances_health","ds_us_west_2_instances_health","ds_ap_south_1_instances_health","ds_ap_northeast_2_instances_health","ds_ap_southeast_1_instances_health","ds_ap_southeast_2_instances_health","ds_ap_northeast_1_instances_health","ds_ca_central_1_instances_health","ds_eu_central_1_instances_health","ds_eu_west_1_instances_health","ds_eu_west_2_instances_health","ds_eu_west_3_instances_health","ds_sa_east_1_instances_health","ds_eu_north_1_instances_health","param_exclude_tags"
   result "content"
   code <<-EOS
     var param_exclude_tags_lower=[];
@@ -138,8 +1324,8 @@ script "js_aws_clb_filter_map", type: "javascript" do
     }
 
     var content=[]
-    for(var i=0; i<ds_aws_clb_list_tags.length; i++){
-      clb=ds_aws_clb_list_tags[i]
+    for(var i=0; i<ds_us_east_1_clb_list_tags.length; i++){
+      clb=ds_us_east_1_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
       var availabilityZones=clb['availabilityZones']
@@ -176,15 +1362,931 @@ script "js_aws_clb_filter_map", type: "javascript" do
           loadBalancerName: clb['loadBalancerName'],
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
-          tagKeyValue:(tagKeyValue.slice(2))
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("us-east-1")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
           // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
           var state= "OutOfService"
           var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
-          for(var k=0; k < ds_aws_instances_health.length; k++){
-            instance= ds_aws_instances_health[k]
+          for(var k=0; k < ds_us_east_1_instances_health.length; k++){
+            instance= ds_us_east_1_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+	
+	for(var i=0; i<ds_us_east_2_clb_list_tags.length; i++){
+      clb=ds_us_east_2_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("us-east-2")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_us_east_2_instances_health.length; k++){
+            instance= ds_us_east_2_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+	
+	for(var i=0; i<ds_us_west_1_clb_list_tags.length; i++){
+      clb=ds_us_west_1_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("us-west-1")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_us_west_1_instances_health.length; k++){
+            instance= ds_us_west_1_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+	
+	for(var i=0; i<ds_us_west_2_clb_list_tags.length; i++){
+      clb=ds_us_west_2_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("us-west-2")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_us_west_2_instances_health.length; k++){
+            instance= ds_us_west_2_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+	
+	for(var i=0; i<ds_ap_south_1_clb_list_tags.length; i++){
+      clb=ds_ap_south_1_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("ap-south-1")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_ap_south_1_instances_health.length; k++){
+            instance= ds_ap_south_1_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+	
+	for(var i=0; i<ds_ap_northeast_2_clb_list_tags.length; i++){
+      clb=ds_ap_northeast_2_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("ap-northeast-2")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_ap_northeast_2_instances_health.length; k++){
+            instance= ds_ap_northeast_2_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+	
+	for(var i=0; i<ds_ap_southeast_1_clb_list_tags.length; i++){
+      clb=ds_ap_southeast_1_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("ap-southeast-1")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_ap_southeast_1_instances_health.length; k++){
+            instance= ds_ap_southeast_1_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+	
+	for(var i=0; i<ds_ap_southeast_2_clb_list_tags.length; i++){
+      clb=ds_ap_southeast_2_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("ap-southeast-2")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_ap_southeast_2_instances_health.length; k++){
+            instance= ds_ap_southeast_2_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+	
+	for(var i=0; i<ds_ap_northeast_1_clb_list_tags.length; i++){
+      clb=ds_ap_northeast_1_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("ap-northeast-1")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_ap_northeast_1_instances_health.length; k++){
+            instance= ds_ap_northeast_1_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+	
+	for(var i=0; i<ds_ca_central_1_clb_list_tags.length; i++){
+      clb=ds_ca_central_1_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("ca-central-1")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_ca_central_1_instances_health.length; k++){
+            instance= ds_ca_central_1_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+	
+	for(var i=0; i<ds_eu_central_1_clb_list_tags.length; i++){
+      clb=ds_eu_central_1_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("eu-central-1")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_eu_central_1_instances_health.length; k++){
+            instance= ds_eu_central_1_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+	
+	for(var i=0; i<ds_eu_west_1_clb_list_tags.length; i++){
+      clb=ds_eu_west_1_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("eu-west-1")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_eu_west_1_instances_health.length; k++){
+            instance= ds_eu_west_1_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+	
+	for(var i=0; i<ds_eu_west_2_clb_list_tags.length; i++){
+      clb=ds_eu_west_2_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("eu-west-2")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_eu_west_2_instances_health.length; k++){
+            instance= ds_eu_west_2_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+	
+	for(var i=0; i<ds_eu_west_3_clb_list_tags.length; i++){
+      clb=ds_eu_west_3_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("eu-west-3")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_eu_west_3_instances_health.length; k++){
+            instance= ds_eu_west_3_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+		
+	for(var i=0; i<ds_sa_east_1_clb_list_tags.length; i++){
+      clb=ds_sa_east_1_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("sa-east-1")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_sa_east_1_instances_health.length; k++){
+            instance= ds_sa_east_1_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+		
+	for(var i=0; i<ds_eu_north_1_clb_list_tags.length; i++){
+      clb=ds_eu_north_1_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2)),
+		  region: ("eu-north-1")
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_eu_north_1_instances_health.length; k++){
+            instance= ds_eu_north_1_instances_health[k]
             if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
               isInstanceNotHealthy=true
             }
@@ -209,10 +2311,10 @@ policy "policy_delete_unused_CLB" do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Unused Classic Load Balancers Found in AWS"
     detail_template <<-EOS
 ## List of Unused Classic Load Balancers
-| LoadBalancer_Name | Instance_ID | Availability_Zones | TAG_Value |
-| ----------------- | ----------- | ------------------ | --------- |
+| LoadBalancer_Name | Region | Instance_ID | Availability_Zones | TAG_Value |
+| ----------------- | ------ | ----------- | ------------------ | --------- |
 {{ range data -}}
-| {{ .loadBalancerName }} | {{ .instanceId }} | {{ .availabilityZones }} | {{.tagKeyValue}} |
+| {{ .loadBalancerName }} | {{.region}} | {{ .instanceId }} | {{ .availabilityZones }} | {{.tagKeyValue}} |
 {{ end -}}
 ###### Policy Applied in Account: {{ rs_project_name }} (Account ID: {{ rs_project_id }}) within Org: {{ rs_org_name }} (Org ID: {{ rs_org_id }})
 EOS
@@ -254,7 +2356,7 @@ define delete_CLB($data) return $all_responses do
   foreach $item in $data do
     sub on_error: skip do
       $response = http_get(
-        url: "https://elasticloadbalancing.amazonaws.com/?Action=DeleteLoadBalancer&Version=2012-06-01&LoadBalancerName="+ $item["loadBalancerName"],
+        url: "https://elasticloadbalancing."+$item["region"]+".amazonaws.com/?Action=DeleteLoadBalancer&Version=2012-06-01&LoadBalancerName="+ $item["loadBalancerName"],
         "signature": { type: "aws" }
       )
       $all_responses << $response

--- a/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
+++ b/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
@@ -1,14 +1,14 @@
-name "AWS Delete Unused Elastic Load Balancers (CLB)"
+name "AWS Delete Unused Classic Load Balancers"
 rs_pt_ver 20180301
 type "policy"
-short_description "Report and remediate any  ELB (CLB) that are not currently in use. \n See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/aws/elb/clb_unused) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
+short_description "Report and remediate any Classic Load Balancers(CLB) that are not currently in use. \n See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/aws/elb/clb_unused) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
 long_description "Version: 1.0"
 category "Cost"
 severity "low"
 
-##################
-# User inputs    #
-##################
+###############################################################################
+# User inputs
+###############################################################################
 
 parameter "param_email" do
   type "list"
@@ -17,9 +17,13 @@ end
 
 parameter "param_exclude_tags" do
   type "list"
-  label "List of one or more Tags that will exclude ELB(CLB) from actions being taken. Format: Key=Value"
+  label "List of one or more Tags that will exclude Classic Load Balancer from actions being taken. Format: Key=Value"
   allowed_pattern /([\w]?)+\=([\w]?)+/
 end
+
+###############################################################################
+# Authentication
+###############################################################################
 
 auth "aws", type: "aws" do
   version "4"
@@ -28,34 +32,38 @@ auth "aws", type: "aws" do
   secret_key cred("AWS_SECRET_ACCESS_KEY")
 end
 
+###############################################################################
+# Datasources
+###############################################################################
+
 #https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html
 datasource "ds_aws_clb_list" do
   request do
-  auth $aws
-  host "elasticloadbalancing.amazonaws.com"
-  path "/"
-  verb "GET"
-  query "Action", "DescribeLoadBalancers"
-  query "Version", "2012-06-01"
-  header "Accept", "application/json"
+    auth $aws
+    host "elasticloadbalancing.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeLoadBalancers"
+    query "Version", "2012-06-01"
+    header "Accept", "application/json"
   end
   result do
-  encoding "json"
-  collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
-    field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
-    field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
-    field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    encoding "json"
+    collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+      field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+      field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+      field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+    end
   end
- end
 end
 
 #https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeTags.html
 datasource "ds_aws_clb_list_tags" do
-iterate $ds_aws_clb_list
+  iterate $ds_aws_clb_list
   request do
-  auth $aws
-  host "elasticloadbalancing.amazonaws.com"
-  path "/"
+    auth $aws
+    host "elasticloadbalancing.amazonaws.com"
+    path "/"
     verb "GET"
     query "Action", "DescribeTags"
     query "Version", "2012-06-01"
@@ -65,24 +73,24 @@ iterate $ds_aws_clb_list
   result do
     encoding "json"
     collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
-    field "tags" do
-    collect jmes_path(col_item,"Tags") do
-      field "tagKey", jmes_path(col_item,"Key")
-      field "tagValue", jmes_path(col_item,"Value")
+      field "tags" do
+        collect jmes_path(col_item,"Tags") do
+          field "tagKey", jmes_path(col_item,"Key")
+          field "tagValue", jmes_path(col_item,"Value")
+        end
+      end
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "availabilityZones", val(iter_item, "availabilityZones")
+      field "instancesList", val(iter_item, "instancesList")
     end
-    end
-    field "loadBalancerName", val(iter_item, "loadBalancerName")
-    field "availabilityZones", val(iter_item, "availabilityZones")
-    field "instancesList", val(iter_item, "instancesList")
-   end
   end
 end
 
 #https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeInstanceHealth.html
 datasource "ds_aws_instances_health" do
-iterate $ds_aws_clb_list
+  iterate $ds_aws_clb_list
   request do
-  auth $aws
+    auth $aws
     host "elasticloadbalancing.amazonaws.com"
     path "/"
     verb "GET"
@@ -92,109 +100,122 @@ iterate $ds_aws_clb_list
     header "Accept", "application/json"
   end
   result do
-  encoding "json"
+    encoding "json"
     collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
-    field "description", jmes_path(col_item,"Description")
-    field "state", jmes_path(col_item,"State")
-    field "instanceId", jmes_path(col_item,"InstanceId")
-    field "loadBalancerName", val(iter_item, "loadBalancerName")
+      field "description", jmes_path(col_item,"Description")
+      field "state", jmes_path(col_item,"State")
+      field "instanceId", jmes_path(col_item,"InstanceId")
+      field "loadBalancerName", val(iter_item, "loadBalancerName")
     end
   end
-end
-
-#https://www.cloudconformity.com/conformity-rules/ELB/unused-elastic-load-balancers.html
-script "js_aws_clb_filter_map", type: "javascript" do
-  parameters "ds_aws_clb_list_tags", "ds_aws_instances_health", "param_exclude_tags"
-	
-  result "content"
-  code <<-EOS
-  var param_exclude_tags_lower=param_exclude_tags.toString().toLowerCase().split(',');
-  var content=[]
-  for(var i=0; i<ds_aws_clb_list_tags.length; i++){
-    clb=ds_aws_clb_list_tags[i]
-
-    // Constructing availabilityZones with comma separated to display in detail_template
-    var availabilityZones=clb['availabilityZones']
-    var s_availabilityZones=""
-    for(var j=0; j < availabilityZones.length; j++){
-      availabilityZone = availabilityZones[j]
-      s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
-    }
-
-    // Constructing IntanceIds with comma separated to display in detail_template
-    var instancesList = clb['instancesList']
-    var s_instanceIds=""
-    for(var j=0; j < instancesList.length; j++){
-      instanceId = instancesList[j]
-      s_instanceIds = s_instanceIds + ', '+ instanceId
-    }
-
-    //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
-    var tags = clb['tags']
-    var isTagMatched=false
-    var tagKeyValue=""
-    for(var j=0; j < tags.length; j++){
-      tag = tags[j]
-      if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
-        isTagMatched = true;
-      }
-      // Constructing tags with comma separated to display in detail_template
-      tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
-    }
-
-    //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
-    if(!(isTagMatched)){
-      clb_details={
-        loadBalancerName: clb['loadBalancerName'],
-        instanceId:(s_instanceIds.slice(2)),
-        availabilityZones:(s_availabilityZones.slice(2)),
-        tagKeyValue:(tagKeyValue.slice(2))
-      }
-      if(instancesList.length > 0){
-        var isInstanceNotHealthy=false
-        // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
-		var state= "OutOfService"
-        var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
-        for(var k=0; k < ds_aws_instances_health.length; k++){
-          instance= ds_aws_instances_health[k]
-          if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
-            isInstanceNotHealthy=true
-          }
-        }
-        if(isInstanceNotHealthy){
-          content.push(clb_details)
-        }
-      }else{
-        content.push(clb_details)
-      }
-    }
-  }
-EOS
 end
 
 datasource "ds_unused_clb_map" do
   run_script $js_aws_clb_filter_map, $ds_aws_clb_list_tags, $ds_aws_instances_health, $param_exclude_tags
 end
 
+###############################################################################
+# Script
+###############################################################################
+
+#https://www.cloudconformity.com/conformity-rules/ELB/unused-elastic-load-balancers.html
+script "js_aws_clb_filter_map", type: "javascript" do
+  parameters "ds_aws_clb_list_tags", "ds_aws_instances_health", "param_exclude_tags"
+  result "content"
+  code <<-EOS
+    var param_exclude_tags_lower=[];
+    for(var j=0; j < param_exclude_tags.length; j++){
+      param_exclude_tags_lower[j]=param_exclude_tags[j].toString().toLowerCase();
+    }
+
+    var content=[]
+    for(var i=0; i<ds_aws_clb_list_tags.length; i++){
+      clb=ds_aws_clb_list_tags[i]
+
+      // Constructing availabilityZones with comma separated to display in detail_template
+      var availabilityZones=clb['availabilityZones']
+      var s_availabilityZones=""
+      for(var j=0; j < availabilityZones.length; j++){
+        availabilityZone = availabilityZones[j]
+        s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+      }
+
+      // Constructing IntanceIds with comma separated to display in detail_template
+      var instancesList = clb['instancesList']
+      var s_instanceIds=""
+      for(var j=0; j < instancesList.length; j++){
+        instanceId = instancesList[j]
+        s_instanceIds = s_instanceIds + ', '+ instanceId
+      }
+
+      //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+      var tags = clb['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if(param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+      }
+
+      //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+      if(!(isTagMatched)){
+        clb_details={
+          loadBalancerName: clb['loadBalancerName'],
+          instanceId:(s_instanceIds.slice(2)),
+          availabilityZones:(s_availabilityZones.slice(2)),
+          tagKeyValue:(tagKeyValue.slice(2))
+        }
+        if(instancesList.length > 0){
+          var isInstanceNotHealthy=false
+          // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+          var state= "OutOfService"
+          var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+          for(var k=0; k < ds_aws_instances_health.length; k++){
+            instance= ds_aws_instances_health[k]
+            if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+              isInstanceNotHealthy=true
+            }
+          }
+          if(isInstanceNotHealthy){
+            content.push(clb_details)
+          }
+        }else{
+          content.push(clb_details)
+        }
+      }
+    }
+  EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
 policy "policy_delete_unused_CLB" do
   validate $ds_unused_clb_map do
-  summary_template "List of Unused Elastic Load Balancers  ELB (CLB) in AWS"
-  detail_template <<-EOS
+    summary_template "List of Unused Classic Load Balancers in AWS"
+    detail_template <<-EOS
 ## List of Unused Classic Load Balancers
-
 | Organization Name | LoadBalancer_Name | Instance_ID | Availability_Zones | TAG_Value |
 | ----------------- | ------------------ | ------------ | ----------------- | --------- |
 {{ range data -}}
 | {{rs_org_name}} | {{ .loadBalancerName }} | {{ .instanceId }} | {{ .availabilityZones }} | {{.tagKeyValue}} |
 {{ end -}}
-
-  ###### Policy Applied in Account: {{ rs_project_name }} (Account ID: {{ rs_project_id }}) within Org: {{ rs_org_name }} (Org ID: {{ rs_org_id }})
-  EOS
-  escalate $report_unused_CLB
-  escalate $approve_delete_CLB
-  check eq(size(data),0)
+###### Policy Applied in Account: {{ rs_project_name }} (Account ID: {{ rs_project_id }}) within Org: {{ rs_org_name }} (Org ID: {{ rs_org_id }})
+EOS
+    escalate $report_unused_CLB
+    escalate $approve_delete_CLB
+    check eq(size(data),0)
   end
 end
+
+###############################################################################
+# Escalations
+###############################################################################
 
 escalation "report_unused_CLB" do
   email $param_email
@@ -205,26 +226,30 @@ escalation "approve_delete_CLB" do
     label "Approve Resource Deletion"
     description "Approve escalation to run RightScale Cloud Workflow to delete unused CLB"
     parameter "approval_reason" do
-    type "string"
-    label "Reason for Approval"
-    description "Explain why you are approving the action"
+      type "string"
+      label "Reason for Approval"
+      description "Explain why you are approving the action"
     end
   end
   run "delete_CLB", data
 end
+
+###############################################################################
+# Cloud Workflow
+###############################################################################
 
 #https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DeleteLoadBalancer.html
 define delete_CLB($data) return $all_responses do
   $$debug=true
   $all_responses = []
   foreach $item in $data do
-  sub on_error: skip do
-    $response = http_get(
-      url: "https://elasticloadbalancing.amazonaws.com/?Action=DeleteLoadBalancer&Version=2012-06-01&LoadBalancerName="+ $item["loadBalancerName"],
-      "signature": { type: "aws" }
-    )
-    $all_responses << $response
-    call sys_log('CLB delete response',to_s($response))
+    sub on_error: skip do
+      $response = http_get(
+        url: "https://elasticloadbalancing.amazonaws.com/?Action=DeleteLoadBalancer&Version=2012-06-01&LoadBalancerName="+ $item["loadBalancerName"],
+        "signature": { type: "aws" }
+      )
+      $all_responses << $response
+      call sys_log('CLB delete response',to_s($response))
     end
   end
 end
@@ -235,7 +260,7 @@ define sys_log($subject, $detail) do
       notify: "None",
       audit_entry: {
         auditee_href: @@account,
-        summary: "AWS Delete Unused ELB(CLB) Policy "+ $subject,
+        summary: "AWS Delete Unused Classic Load Balancers Policy "+ $subject,
         detail: $detail
       }
     )

--- a/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
+++ b/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
@@ -1363,7 +1363,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("us-east-1")
+          region: ("us-east-1")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -1385,7 +1385,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 	
-	for(var i=0; i<ds_us_east_2_clb_list_tags.length; i++){
+    for(var i=0; i<ds_us_east_2_clb_list_tags.length; i++){
       clb=ds_us_east_2_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -1424,7 +1424,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("us-east-2")
+          region: ("us-east-2")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -1446,7 +1446,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 	
-	for(var i=0; i<ds_us_west_1_clb_list_tags.length; i++){
+    for(var i=0; i<ds_us_west_1_clb_list_tags.length; i++){
       clb=ds_us_west_1_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -1485,7 +1485,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("us-west-1")
+          region: ("us-west-1")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -1507,7 +1507,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 	
-	for(var i=0; i<ds_us_west_2_clb_list_tags.length; i++){
+    for(var i=0; i<ds_us_west_2_clb_list_tags.length; i++){
       clb=ds_us_west_2_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -1546,7 +1546,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("us-west-2")
+          region: ("us-west-2")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -1568,7 +1568,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 	
-	for(var i=0; i<ds_ap_south_1_clb_list_tags.length; i++){
+    for(var i=0; i<ds_ap_south_1_clb_list_tags.length; i++){
       clb=ds_ap_south_1_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -1607,7 +1607,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("ap-south-1")
+          region: ("ap-south-1")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -1629,7 +1629,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 	
-	for(var i=0; i<ds_ap_northeast_2_clb_list_tags.length; i++){
+    for(var i=0; i<ds_ap_northeast_2_clb_list_tags.length; i++){
       clb=ds_ap_northeast_2_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -1668,7 +1668,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("ap-northeast-2")
+          region: ("ap-northeast-2")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -1690,7 +1690,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 	
-	for(var i=0; i<ds_ap_southeast_1_clb_list_tags.length; i++){
+    for(var i=0; i<ds_ap_southeast_1_clb_list_tags.length; i++){
       clb=ds_ap_southeast_1_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -1729,7 +1729,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("ap-southeast-1")
+          region: ("ap-southeast-1")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -1751,7 +1751,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 	
-	for(var i=0; i<ds_ap_southeast_2_clb_list_tags.length; i++){
+    for(var i=0; i<ds_ap_southeast_2_clb_list_tags.length; i++){
       clb=ds_ap_southeast_2_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -1790,7 +1790,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("ap-southeast-2")
+          region: ("ap-southeast-2")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -1812,7 +1812,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 	
-	for(var i=0; i<ds_ap_northeast_1_clb_list_tags.length; i++){
+    for(var i=0; i<ds_ap_northeast_1_clb_list_tags.length; i++){
       clb=ds_ap_northeast_1_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -1851,7 +1851,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("ap-northeast-1")
+          region: ("ap-northeast-1")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -1873,7 +1873,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 	
-	for(var i=0; i<ds_ca_central_1_clb_list_tags.length; i++){
+    for(var i=0; i<ds_ca_central_1_clb_list_tags.length; i++){
       clb=ds_ca_central_1_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -1912,7 +1912,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("ca-central-1")
+          region: ("ca-central-1")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -1934,7 +1934,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 	
-	for(var i=0; i<ds_eu_central_1_clb_list_tags.length; i++){
+    for(var i=0; i<ds_eu_central_1_clb_list_tags.length; i++){
       clb=ds_eu_central_1_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -1973,7 +1973,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("eu-central-1")
+          region: ("eu-central-1")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -1995,7 +1995,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 	
-	for(var i=0; i<ds_eu_west_1_clb_list_tags.length; i++){
+    for(var i=0; i<ds_eu_west_1_clb_list_tags.length; i++){
       clb=ds_eu_west_1_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -2034,7 +2034,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("eu-west-1")
+          region: ("eu-west-1")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -2056,7 +2056,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 	
-	for(var i=0; i<ds_eu_west_2_clb_list_tags.length; i++){
+    for(var i=0; i<ds_eu_west_2_clb_list_tags.length; i++){
       clb=ds_eu_west_2_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -2095,7 +2095,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("eu-west-2")
+          region: ("eu-west-2")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -2117,7 +2117,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 	
-	for(var i=0; i<ds_eu_west_3_clb_list_tags.length; i++){
+    for(var i=0; i<ds_eu_west_3_clb_list_tags.length; i++){
       clb=ds_eu_west_3_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -2156,7 +2156,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("eu-west-3")
+          region: ("eu-west-3")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -2178,7 +2178,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 		
-	for(var i=0; i<ds_sa_east_1_clb_list_tags.length; i++){
+    for(var i=0; i<ds_sa_east_1_clb_list_tags.length; i++){
       clb=ds_sa_east_1_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -2217,7 +2217,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("sa-east-1")
+          region: ("sa-east-1")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false
@@ -2239,7 +2239,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       }
     }
 		
-	for(var i=0; i<ds_eu_north_1_clb_list_tags.length; i++){
+    for(var i=0; i<ds_eu_north_1_clb_list_tags.length; i++){
       clb=ds_eu_north_1_clb_list_tags[i]
 
       // Constructing availabilityZones with comma separated to display in detail_template
@@ -2278,7 +2278,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
           instanceId:(s_instanceIds.slice(2)),
           availabilityZones:(s_availabilityZones.slice(2)),
           tagKeyValue:(tagKeyValue.slice(2)),
-		  region: ("eu-north-1")
+          region: ("eu-north-1")
         }
         if(instancesList.length > 0){
           var isInstanceNotHealthy=false

--- a/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
+++ b/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
@@ -17,7 +17,7 @@ end
 
 parameter "param_exclude_tags" do
   type "list"
-  label "List of one or more Tags that will exclude ELB(CLB) from actions being taken. Format: Key=Value separated by comma"
+  label "List of one or more Tags that will exclude ELB(CLB) from actions being taken. Format: Key=Value"
   allowed_pattern /([\w]?)+\=([\w]?)+/
 end
 
@@ -105,7 +105,7 @@ end
 #https://www.cloudconformity.com/conformity-rules/ELB/unused-elastic-load-balancers.html
 script "js_aws_clb_filter_map", type: "javascript" do
   parameters "ds_aws_clb_list_tags", "ds_aws_instances_health", "param_exclude_tags"
-
+	
   result "content"
   code <<-EOS
   var content=[]
@@ -134,7 +134,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
     var tagKeyValue=""
     for(var j=0; j < tags.length; j++){
       tag = tags[j]
-      if(param_exclude_tags.indexOf(tag['tagKey']+'='+tag['tagValue']) !== -1){
+      if(((param_exclude_tags.join()+',').toLowerCase()).indexOf((tag['tagKey']+'='+tag['tagValue']+',').toLowerCase()) !== -1){
         isTagMatched = true;
       }
       // Constructing tags with comma separated to display in detail_template
@@ -152,7 +152,7 @@ script "js_aws_clb_filter_map", type: "javascript" do
       if(instancesList.length > 0){
         var isInstanceNotHealthy=false
         // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
-    var state= "OutOfService"
+		var state= "OutOfService"
         var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
         for(var k=0; k < ds_aws_instances_health.length; k++){
           instance= ds_aws_instances_health[k]

--- a/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
+++ b/cost/aws/elb/clb_unused/AWS_Delete_Unused_CLB.pt
@@ -1,0 +1,242 @@
+name "AWS Delete Unused Elastic Load Balancers (CLB)"
+rs_pt_ver 20180301
+type "policy"
+short_description "Report and remediate any  ELB (CLB) that are not currently in use. \n See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/aws/elb/clb_unused) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
+long_description "Version: 1.0"
+category "Cost"
+severity "low"
+
+##################
+# User inputs    #
+##################
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses of the recipients you wish to notify"
+end
+
+parameter "param_exclude_tags" do
+  type "list"
+  label "List of one or more Tags that will exclude ELB(CLB) from actions being taken. Format: Key=Value separated by comma"
+  allowed_pattern /([\w]?)+\=([\w]?)+/
+end
+
+auth "aws", type: "aws" do
+  version "4"
+  service "elasticloadbalancing"
+  access_key cred("AWS_ACCESS_KEY_ID")
+  secret_key cred("AWS_SECRET_ACCESS_KEY")
+end
+
+#https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeLoadBalancers.html
+datasource "ds_aws_clb_list" do
+  request do
+  auth $aws
+  host "elasticloadbalancing.amazonaws.com"
+  path "/"
+  verb "GET"
+  query "Action", "DescribeLoadBalancers"
+  query "Version", "2012-06-01"
+  header "Accept", "application/json"
+  end
+  result do
+  encoding "json"
+  collect jmes_path(response, "DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancerDescriptions[*]") do
+    field "loadBalancerName", jmes_path(col_item, "LoadBalancerName")
+    field "availabilityZones", jmes_path(col_item, "AvailabilityZones")
+    field "instancesList", jmes_path(col_item, "Instances[*].InstanceId")
+  end
+ end
+end
+
+#https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeTags.html
+datasource "ds_aws_clb_list_tags" do
+iterate $ds_aws_clb_list
+  request do
+  auth $aws
+  host "elasticloadbalancing.amazonaws.com"
+  path "/"
+    verb "GET"
+    query "Action", "DescribeTags"
+    query "Version", "2012-06-01"
+    query "LoadBalancerNames.member.1",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "DescribeTagsResponse.DescribeTagsResult.TagDescriptions[*]") do
+    field "tags" do
+    collect jmes_path(col_item,"Tags") do
+      field "tagKey", jmes_path(col_item,"Key")
+      field "tagValue", jmes_path(col_item,"Value")
+    end
+    end
+    field "loadBalancerName", val(iter_item, "loadBalancerName")
+    field "availabilityZones", val(iter_item, "availabilityZones")
+    field "instancesList", val(iter_item, "instancesList")
+   end
+  end
+end
+
+#https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DescribeInstanceHealth.html
+datasource "ds_aws_instances_health" do
+iterate $ds_aws_clb_list
+  request do
+  auth $aws
+    host "elasticloadbalancing.amazonaws.com"
+    path "/"
+    verb "GET"
+    query "Action", "DescribeInstanceHealth"
+    query "Version", "2012-06-01"
+    query "LoadBalancerName",val(iter_item, "loadBalancerName")
+    header "Accept", "application/json"
+  end
+  result do
+  encoding "json"
+    collect jmes_path(response, "DescribeInstanceHealthResponse.DescribeInstanceHealthResult.InstanceStates[*]") do
+    field "description", jmes_path(col_item,"Description")
+    field "state", jmes_path(col_item,"State")
+    field "instanceId", jmes_path(col_item,"InstanceId")
+    field "loadBalancerName", val(iter_item, "loadBalancerName")
+    end
+  end
+end
+
+#https://www.cloudconformity.com/conformity-rules/ELB/unused-elastic-load-balancers.html
+script "js_aws_clb_filter_map", type: "javascript" do
+  parameters "ds_aws_clb_list_tags", "ds_aws_instances_health", "param_exclude_tags"
+
+  result "content"
+  code <<-EOS
+  var content=[]
+  for(var i=0; i<ds_aws_clb_list_tags.length; i++){
+    clb=ds_aws_clb_list_tags[i]
+
+    // Constructing availabilityZones with comma separated to display in detail_template
+    var availabilityZones=clb['availabilityZones']
+    var s_availabilityZones=""
+    for(var j=0; j < availabilityZones.length; j++){
+      availabilityZone = availabilityZones[j]
+      s_availabilityZones = s_availabilityZones + ', '+ availabilityZone
+    }
+
+    // Constructing IntanceIds with comma separated to display in detail_template
+    var instancesList = clb['instancesList']
+    var s_instanceIds=""
+    for(var j=0; j < instancesList.length; j++){
+      instanceId = instancesList[j]
+      s_instanceIds = s_instanceIds + ', '+ instanceId
+    }
+
+    //Constructing Tags of individual CLB into key=value format. Check, if the tag present in entered param_exclude_tags, ignore the CLB if the tag matches/present.
+    var tags = clb['tags']
+    var isTagMatched=false
+    var tagKeyValue=""
+    for(var j=0; j < tags.length; j++){
+      tag = tags[j]
+      if(param_exclude_tags.indexOf(tag['tagKey']+'='+tag['tagValue']) !== -1){
+        isTagMatched = true;
+      }
+      // Constructing tags with comma separated to display in detail_template
+      tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+    }
+
+    //If the CLB tag does not match with entered param_exclude_tags, then check if any instance exists in the CLB and check for instances health.
+    if(!(isTagMatched)){
+      clb_details={
+        loadBalancerName: clb['loadBalancerName'],
+        instanceId:(s_instanceIds.slice(2)),
+        availabilityZones:(s_availabilityZones.slice(2)),
+        tagKeyValue:(tagKeyValue.slice(2))
+      }
+      if(instancesList.length > 0){
+        var isInstanceNotHealthy=false
+        // Check if the CLB has no healthy instance with state and description matches for the values mentioned below
+    var state= "OutOfService"
+        var description= "Instance has failed at least the UnhealthyThreshold number of health checks consecutively."
+        for(var k=0; k < ds_aws_instances_health.length; k++){
+          instance= ds_aws_instances_health[k]
+          if(((instance['loadBalancerName']) == (clb['loadBalancerName'])) && (instance['state'] == state && instance['description'] == description)){
+            isInstanceNotHealthy=true
+          }
+        }
+        if(isInstanceNotHealthy){
+          content.push(clb_details)
+        }
+      }else{
+        content.push(clb_details)
+      }
+    }
+  }
+EOS
+end
+
+datasource "ds_unused_clb_map" do
+  run_script $js_aws_clb_filter_map, $ds_aws_clb_list_tags, $ds_aws_instances_health, $param_exclude_tags
+end
+
+policy "policy_delete_unused_CLB" do
+  validate $ds_unused_clb_map do
+  summary_template "List of Unused Elastic Load Balancers  ELB (CLB) in AWS"
+  detail_template <<-EOS
+## List of Unused Classic Load Balancers
+
+| Organization Name | LoadBalancer_Name | Instance_ID | Availability_Zones | TAG_Value |
+| ----------------- | ------------------ | ------------ | ----------------- | --------- |
+{{ range data -}}
+| {{rs_org_name}} | {{ .loadBalancerName }} | {{ .instanceId }} | {{ .availabilityZones }} | {{.tagKeyValue}} |
+{{ end -}}
+
+  ###### Policy Applied in Account: {{ rs_project_name }} (Account ID: {{ rs_project_id }}) within Org: {{ rs_org_name }} (Org ID: {{ rs_org_id }})
+  EOS
+  escalate $report_unused_CLB
+  escalate $approve_delete_CLB
+  check eq(size(data),0)
+  end
+end
+
+escalation "report_unused_CLB" do
+  email $param_email
+end
+
+escalation "approve_delete_CLB" do
+  request_approval  do
+    label "Approve Resource Deletion"
+    description "Approve escalation to run RightScale Cloud Workflow to delete unused CLB"
+    parameter "approval_reason" do
+    type "string"
+    label "Reason for Approval"
+    description "Explain why you are approving the action"
+    end
+  end
+  run "delete_CLB", data
+end
+
+#https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_DeleteLoadBalancer.html
+define delete_CLB($data) return $all_responses do
+  $$debug=true
+  $all_responses = []
+  foreach $item in $data do
+  sub on_error: skip do
+    $response = http_get(
+      url: "https://elasticloadbalancing.amazonaws.com/?Action=DeleteLoadBalancer&Version=2012-06-01&LoadBalancerName="+ $item["loadBalancerName"],
+      "signature": { type: "aws" }
+    )
+    $all_responses << $response
+    call sys_log('CLB delete response',to_s($response))
+    end
+  end
+end
+
+define sys_log($subject, $detail) do
+  if $$debug
+    rs_cm.audit_entries.create(
+      notify: "None",
+      audit_entry: {
+        auditee_href: @@account,
+        summary: "AWS Delete Unused ELB(CLB) Policy "+ $subject,
+        detail: $detail
+      }
+    )
+  end
+end

--- a/cost/aws/elb/clb_unused/CHANGELOG.md
+++ b/cost/aws/elb/clb_unused/CHANGELOG.md
@@ -1,0 +1,3 @@
+v1.0
+-----
+- initial release

--- a/cost/aws/elb/clb_unused/README.md
+++ b/cost/aws/elb/clb_unused/README.md
@@ -1,0 +1,27 @@
+## AWS Unused  ELB (CLB) 
+ 
+### What it does
+This policy checks all  ELB (CLB) to determine if any are unused (have no healthy instances) and allows them to be deleted by the user after approval.
+ 
+### Functional Details
+ 
+The policy leverages the AWS EC2 API to determine if the  ELB (CLB) is in use.
+ 
+When an unused  ELB (CLB) is detected, an email action is triggered automatically to notify the specified users of the incident. Users then have the option to delete the  ELB (CLB) after manual approval if needed.
+ 
+#### Input Parameters
+ 
+- *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
+- *Ignore tags* -  ELB (CLB) with any of these tags will be ignored 
+ 
+### Required RightScale Roles
+ 
+- policy_manager
+ 
+### Supported Clouds
+ 
+- AWS
+ 
+### Cost
+ 
+This Policy Template does not incur any cloud costs.

--- a/cost/aws/elb/clb_unused/README.md
+++ b/cost/aws/elb/clb_unused/README.md
@@ -1,9 +1,9 @@
 ## AWS Unused Classic Load Balancers (CLB) 
  
 ### What it does
-This policy checks all CLB to determine if any are unused (have no healthy instances) and allows them to be deleted by the user after approval.
+This policy checks all Classic Load Balancers (CLB) to determine if any are unused (have no healthy instances) and allows them to be deleted by the user after approval.
 
-Note:Elastic Load Balancing (ELB) supports three types of load balancers: Application Load Balancers, Network Load Balancers, and Classic Load Balancers.
+Note:Elastic Load Balancing (ELB) supports three types of load balancers: Application Load Balancers, Network Load Balancers and Classic Load Balancers.
 
 ### Functional Details
  
@@ -23,7 +23,7 @@ When an unused CLB is detected, an email action is triggered automatically to no
 
 ### AWS Required Permissions
 
-This policy requires permissions to describe AWS LoadBalancers,InstanceHealth, tags and DeleteLoadBalancer. 
+This policy requires permissions to describe AWS LoadBalancers, InstanceHealth, tags and DeleteLoadBalancer.
 The Cloud Management Platform automatically creates two Credentials when connecting AWS to Cloud Management; AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. The IAM user credentials contained in those credentials will require the following permissions:
 
 ```javascript

--- a/cost/aws/elb/clb_unused/README.md
+++ b/cost/aws/elb/clb_unused/README.md
@@ -1,23 +1,46 @@
-## AWS Unused  ELB (CLB) 
+## AWS Unused Classic Load Balancers (CLB) 
  
 ### What it does
-This policy checks all  ELB (CLB) to determine if any are unused (have no healthy instances) and allows them to be deleted by the user after approval.
- 
+This policy checks all CLB to determine if any are unused (have no healthy instances) and allows them to be deleted by the user after approval.
+
+Note:Elastic Load Balancing (ELB) supports three types of load balancers: Application Load Balancers, Network Load Balancers, and Classic Load Balancers.
+
 ### Functional Details
  
-The policy leverages the AWS EC2 API to determine if the  ELB (CLB) is in use.
+The policy leverages the AWS elasticloadbalancing API to determine if the CLB is in use.
  
-When an unused  ELB (CLB) is detected, an email action is triggered automatically to notify the specified users of the incident. Users then have the option to delete the  ELB (CLB) after manual approval if needed.
+When an unused CLB is detected, an email action is triggered automatically to notify the specified users of the incident. Users then have the option to delete the CLB after manual approval if needed.
  
 #### Input Parameters
  
 - *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
-- *Ignore tags* -  ELB (CLB) with any of these tags will be ignored 
+- *Ignore tags* - CLB with any of these tags will be ignored 
  
 ### Required RightScale Roles
  
 - policy_manager
- 
+- admin or credential_viewer
+
+### AWS Required Permissions
+
+This policy requires permissions to describe AWS LoadBalancers,InstanceHealth, tags and DeleteLoadBalancer. 
+The Cloud Management Platform automatically creates two Credentials when connecting AWS to Cloud Management; AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. The IAM user credentials contained in those credentials will require the following permissions:
+
+```javascript
+{
+    "Version": "2012-06-01",
+    "Statement":[{
+    "Effect":"Allow",
+    "Action":["elasticloadbalancing:DescribeLoadBalancers",
+              "elasticloadbalancing:DescribeInstanceHealth",
+			  "elasticloadbalancing:DescribeTags",
+			  "elasticloadbalancing:DeleteLoadBalancer"],
+    "Resource":"*"
+    }
+  ]
+}
+```
+
 ### Supported Clouds
  
 - AWS

--- a/cost/aws/elb/clb_unused/README.md
+++ b/cost/aws/elb/clb_unused/README.md
@@ -33,8 +33,8 @@ The Cloud Management Platform automatically creates two Credentials when connect
     "Effect":"Allow",
     "Action":["elasticloadbalancing:DescribeLoadBalancers",
               "elasticloadbalancing:DescribeInstanceHealth",
-			  "elasticloadbalancing:DescribeTags",
-			  "elasticloadbalancing:DeleteLoadBalancer"],
+	      "elasticloadbalancing:DescribeTags",
+	      "elasticloadbalancing:DeleteLoadBalancer"],
     "Resource":"*"
     }
   ]


### PR DESCRIPTION
### Description

This policy checks all  ELB (CLB) to determine if any are unused (have no healthy instances) and allows them to be deleted by the user after approval.

### Issues Resolved

When an unused  ELB (CLB) is detected, an email action is triggered automatically to notify the specified users of the incident. Users then have the option to delete the  ELB (CLB) after manual approval if needed.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD

### Screen shot of incident details
![Incident-AWS Delete Unused CLB](https://user-images.githubusercontent.com/47382786/55151373-1f9dc400-5174-11e9-93fa-2fbee567f24e.jpg)

### Running policy Link.
- https://governance.rightscale.com/org/1105/projects/60073/applied-policies/5c9ca28c1e88c80088e2ad4d