### PR TITLE
POL-35 AWS Publicly Accessible RDS Instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Please contact sales@rightscale.com to learn more.
 - [Google Open Buckets Policy](./security/storage/google/public_buckets/)
 - [AWS Unencrypted Volumes Policy](./security/aws/ebs_unencrypted_volumes/)
 - [AWS Internet-facing ELBs & ALBs](./security/aws/loadbalancer_internet_facing/)
+- [AWS Unencrypted RDS Instances](./security/aws/rds_unencrypted/)
+- [AWS Publicly Accessible RDS Instances](./security/aws/rds_publicly_accessible/)
 
 ### Compliance
 - [Untagged Resources](./compliance/tags/tag_checker)

--- a/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt
+++ b/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt
@@ -160,7 +160,7 @@ script "js_rds_list", type: "javascript" do
       auth: 'auth_aws',
       host: 'rds.'+region+'.amazonaws.com',
       path: '/',
-      pagination: "rds_list_pagination",
+      pagination: "rds_pagination",
       query_params: {
         "Action": "DescribeDBInstances",
         "Version": "2014-10-31",
@@ -251,7 +251,8 @@ script "js_rds_filter_map", type: "javascript" do
           storage_encrypted: storage_encrypted,
           db_instance_status: rds['db_instance_status'],
           db_cluster_identifier: rds['db_cluster_identifier'],
-          delete_protection: delete_protection		  
+          delete_protection: delete_protection,
+          publicly_accessible: rds['publicly_accessible']
         })
       }
     }
@@ -282,7 +283,7 @@ policy "policy_rds_instance_list" do
     # eq(val(item, "delete_protection"), "YES"),
     # ne(val(item, "db_instance_status"), "available")
     #)
-    check eq(val(item, "publicly_accessible"), "false")
+    check logic_not(val(item, "publicly_accessible"))
     #And comment above line (add '#' at beginning) when you enable Delete action.
     end
 end

--- a/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt
+++ b/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt
@@ -251,7 +251,24 @@ script "js_regions_map", type: "javascript" do
   result "regions_map"
   code <<-EOS
     var regions_map=[]
-    regions_map.push({"region": "us-east-1"}, {"region": "us-east-2"}, {"region": "us-west-1"}, {"region": "us-west-2"}, {"region": "ap-south-1"}, {"region": "ap-northeast-2"}, {"region": "ap-southeast-1"}, {"region": "ap-southeast-2"}, {"region": "ap-northeast-1"}, {"region": "ca-central-1"}, {"region": "eu-central-1"}, {"region": "eu-west-1"}, {"region": "eu-west-2"}, {"region": "eu-west-3"}, {"region": "sa-east-1"}, {"region": "eu-north-1"})
+    regions_map.push(
+      {"region": "us-east-1"},
+      {"region": "us-east-2"},
+      {"region": "us-west-1"},
+      {"region": "us-west-2"},
+      {"region": "ap-south-1"},
+      {"region": "ap-northeast-2"},
+      {"region": "ap-southeast-1"},
+      {"region": "ap-southeast-2"},
+      {"region": "ap-northeast-1"},
+      {"region": "ca-central-1"},
+      {"region": "eu-central-1"},
+      {"region": "eu-west-1"},
+      {"region": "eu-west-2"},
+      {"region": "eu-west-3"},
+      {"region": "sa-east-1"},
+      {"region": "eu-north-1"}
+    )
   EOS
 end
 
@@ -380,7 +397,7 @@ policy "policy_rds_instance_list" do
     EOS
     escalate $report_publicly_accessible_RDS_instances
     escalate $modify_publicly_accessible_RDS_instance_approval
-	#Kindly uncomment (remove '#') in the below line to enable Delete action.
+    #uncomment (remove '#') in the below line to enable Delete action.
     #escalate $delete_publicly_accessible_RDS_instances_approval
     check eq(size(data),0)
   end
@@ -448,7 +465,6 @@ define delete_publicly_acessible_RDS_instances($data) return $all_responses do
   $all_responses = []
   foreach $item in $data do
     sub on_error: skip do
-
       if ($item['dbCluster_Identifier'] != null) && ($item["delete_Protection"] == 'No')
        #Creating Cluster snapshot manually Since DB instance snapshot cannot be created directly for Aurora cluster DB instance.
         $create_cluster_snapshot = http_get(

--- a/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt
+++ b/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt
@@ -35,132 +35,11 @@ end
 # Authentication
 ###############################################################################
 
-auth "auth_us_east_1", type: "aws" do
+auth "auth_aws", type: "aws" do
   version "4"
   service "rds"
-  region 'us-east-1'
   access_key cred("AWS_ACCESS_KEY_ID")
   secret_key cred("AWS_SECRET_ACCESS_KEY")
-end
-
-auth "auth_us_east_2", type: "aws" do
-  version "4"
-  service "rds"
-  region 'us-east-2'
-  access_key cred("AWS_ACCESS_KEY_ID")
-  secret_key cred("AWS_SECRET_ACCESS_KEY")
-end
-
-auth "auth_us_west_1", type: "aws" do
-  version "4"
-  service "rds"
-  region 'us-west-1'
-  access_key cred("AWS_ACCESS_KEY_ID")
-  secret_key cred("AWS_SECRET_ACCESS_KEY")
-end
-
-auth "auth_us_west_2", type: "aws" do
-  version "4"
-  service "rds"
-  region 'us-west-2'
-  access_key cred("AWS_ACCESS_KEY_ID")
-  secret_key cred("AWS_SECRET_ACCESS_KEY")
-end
-
-auth "auth_ap_south_1", type: "aws" do
-  version 4
-  service "rds"
-  region 'ap-south-1'
-  access_key cred('AWS_ACCESS_KEY_ID')
-  secret_key cred('AWS_SECRET_ACCESS_KEY')
-end
-
-auth "auth_ap_northeast_2", type: "aws" do
-  version 4
-  service "rds"
-  region 'ap-northeast-2'
-  access_key cred('AWS_ACCESS_KEY_ID')
-  secret_key cred('AWS_SECRET_ACCESS_KEY')
-end
-
-auth "auth_ap_southeast_1", type: "aws" do
-  version 4
-  service "rds"
-  region 'ap-southeast-1'
-  access_key cred('AWS_ACCESS_KEY_ID')
-  secret_key cred('AWS_SECRET_ACCESS_KEY')
-end
-
-auth "auth_ap_southeast_2", type: "aws" do
-  version 4
-  service "rds"
-  region 'ap-southeast-2'
-  access_key cred('AWS_ACCESS_KEY_ID')
-  secret_key cred('AWS_SECRET_ACCESS_KEY')
-end
-
-auth "auth_ap_northeast_1", type: "aws" do
-  version 4
-  service "rds"
-  region 'ap-northeast-1'
-  access_key cred('AWS_ACCESS_KEY_ID')
-  secret_key cred('AWS_SECRET_ACCESS_KEY')
-end
-
-auth "auth_ca_central_1", type: "aws" do
-  version 4
-  service "rds"
-  region 'ca-central-1'
-  access_key cred('AWS_ACCESS_KEY_ID')
-  secret_key cred('AWS_SECRET_ACCESS_KEY')
-end
-
-auth "auth_eu_central_1", type: "aws" do
-  version 4
-  service "rds"
-  region 'eu-central-1'
-  access_key cred('AWS_ACCESS_KEY_ID')
-  secret_key cred('AWS_SECRET_ACCESS_KEY')
-end
-
-auth "auth_eu_west_1", type: "aws" do
-  version 4
-  service "rds"
-  region 'eu-west-1'
-  access_key cred('AWS_ACCESS_KEY_ID')
-  secret_key cred('AWS_SECRET_ACCESS_KEY')
-end
-
-auth "auth_eu_west_2", type: "aws" do
-  version 4
-  service "rds"
-  region 'eu-west-2'
-  access_key cred('AWS_ACCESS_KEY_ID')
-  secret_key cred('AWS_SECRET_ACCESS_KEY')
-end
-
-auth "auth_eu_west_3", type: "aws" do
-  version 4
-  service "rds"
-  region 'eu-west-3'
-  access_key cred('AWS_ACCESS_KEY_ID')
-  secret_key cred('AWS_SECRET_ACCESS_KEY')
-end
-
-auth "auth_sa_east_1", type: "aws" do
-  version 4
-  service "rds"
-  region 'sa-east-1'
-  access_key cred('AWS_ACCESS_KEY_ID')
-  secret_key cred('AWS_SECRET_ACCESS_KEY')
-end
-
-auth "auth_eu_north_1", type: "aws" do
-  version 4
-  service "rds"
-  region 'eu-north-1'
-  access_key cred('AWS_ACCESS_KEY_ID')
-  secret_key cred('AWS_SECRET_ACCESS_KEY')
 end
 
 ###############################################################################
@@ -194,17 +73,17 @@ datasource "ds_rds_instances_list" do
   result do
    encoding "json"
     collect jmes_path(response, "DescribeDBInstancesResponse.DescribeDBInstancesResult.DBInstances[*]") do
-      field "dbInstanceArn", jmes_path(col_item, "DBInstanceArn")
-      field "dbInstance_Identifier", jmes_path(col_item, "DBInstanceIdentifier")
-      field "publicly_Accessible", jmes_path(col_item, "PubliclyAccessible")
-      field "storage_Encrypted", jmes_path(col_item, "StorageEncrypted")
-      field "dbName", jmes_path(col_item, "Engine")
-      field "delete_Protection", jmes_path(col_item, "DeletionProtection")
+      field "db_instance_arn", jmes_path(col_item, "DBInstanceArn")
+      field "db_instance_identifier", jmes_path(col_item, "DBInstanceIdentifier")
+      field "publicly_accessible", jmes_path(col_item, "PubliclyAccessible")
+      field "storage_encrypted", jmes_path(col_item, "StorageEncrypted")
+      field "db_engine_name", jmes_path(col_item, "Engine")
+      field "delete_protection", jmes_path(col_item, "DeletionProtection")
       field "availability_zone", jmes_path(col_item, "AvailabilityZone")
       field "sec_availability_zone", jmes_path(col_item, "SecondaryAvailabilityZone")
       field "db_instance_status", jmes_path(col_item,"DBInstanceStatus")
       field "region", val(iter_item,"region")
-      field "dbCluster_Identifier", jmes_path(col_item,"DBClusterIdentifier")
+      field "db_cluster_identifier", jmes_path(col_item,"DBClusterIdentifier")
     end
   end
 end
@@ -213,7 +92,7 @@ end
 datasource "ds_rds_list_with_tags" do
   iterate $ds_rds_instances_list
   request do
-    run_script $js_rds_list_with_tags, val(iter_item,"region"), val(iter_item, "dbInstanceArn")
+    run_script $js_rds_list_with_tags, val(iter_item,"region"), val(iter_item, "db_instance_arn")
   end
   result do
     encoding "json"
@@ -224,17 +103,17 @@ datasource "ds_rds_list_with_tags" do
           field "tagValue", jmes_path(col_item, "Value")
         end
       end
-      field "dbInstanceArn", val(iter_item, "dbInstanceArn")
-      field "dbInstance_Identifier", val(iter_item, "dbInstance_Identifier")
-      field "publicly_Accessible", val(iter_item, "publicly_Accessible")
-      field "storage_Encrypted", val(iter_item, "storage_Encrypted")
-      field "delete_Protection", val(iter_item, "delete_Protection")
+      field "db_instance_arn", val(iter_item, "db_instance_arn")
+      field "db_instance_identifier", val(iter_item, "db_instance_identifier")
+      field "publicly_accessible", val(iter_item, "publicly_accessible")
+      field "storage_encrypted", val(iter_item, "storage_encrypted")
+      field "delete_protection", val(iter_item, "delete_protection")
       field "region", val(iter_item,"region")
-      field "dbName", val(iter_item,"dbName")
+      field "db_engine_name", val(iter_item,"db_engine_name")
       field "availability_zone", val(iter_item, "availability_zone")
       field "sec_availability_zone", val(iter_item, "sec_availability_zone")
       field "db_instance_status", val(iter_item,"db_instance_status")
-      field "dbCluster_Identifier", val(iter_item,"dbCluster_Identifier")
+      field "db_cluster_identifier", val(iter_item,"db_cluster_identifier")
     end
   end
 end
@@ -278,7 +157,7 @@ script "js_rds_list", type: "javascript" do
   result "results"
   code <<-EOS
     results = {
-      auth: "auth_"+region.replace(/-/g,"_"),
+      auth: 'auth_aws',
       host: 'rds.'+region+'.amazonaws.com',
       path: '/',
       pagination: "rds_list_pagination",
@@ -295,18 +174,18 @@ end
 
 #https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ListTagsForResource.html
 script "js_rds_list_with_tags", type: "javascript" do
-  parameters "region", "dbInstanceArn"
+  parameters "region", "db_instance_arn"
   result "request"
   code <<-EOS
     request = {
-      auth: 'auth_'+region.replace(/-/g,"_"),
+      auth: 'auth_aws',
       host: 'rds.'+region+'.amazonaws.com',
       path: '/',
       verb: 'GET',
       query_params: {
         "Action": "ListTagsForResource",
         "Version": "2014-10-31",
-        "ResourceName": dbInstanceArn,
+        "ResourceName": db_instance_arn,
       },
       headers: {
         "Accept": "application/json"
@@ -346,33 +225,33 @@ script "js_rds_filter_map", type: "javascript" do
         }
       }
 
-      var storage_Encrypted = rds['storage_Encrypted'];
-      if(storage_Encrypted === true){
-        storage_Encrypted = 'Yes';
+      var storage_encrypted = rds['storage_encrypted'];
+      if(storage_encrypted === true){
+        storage_encrypted = 'Yes';
       }else{
-        storage_Encrypted = 'No';
+        storage_encrypted = 'No';
       }  
-      var delete_Protection = rds['delete_Protection'];
-      if(delete_Protection === true){
-        delete_Protection = 'Yes';
+      var delete_protection = rds['delete_protection'];
+      if(delete_protection === true){
+        delete_protection = 'Yes';
       }else{
-        delete_Protection = 'No';
+        delete_protection = 'No';
       }
 
       //If the RDS instance tag does not match with entered param_exclude_tags, then check if RDS instance is Publicly Accessible
-      if(!(isTagMatched) && (rds['publicly_Accessible']) === true){
+      if(!(isTagMatched) && (rds['publicly_accessible']) === true){
         content.push({
-          dbInstanceArn: rds['dbInstanceArn'],
-          dbName: rds['dbName'],
+          db_instance_arn: rds['db_instance_arn'],
+          db_engine_name: rds['db_engine_name'],
           region: rds['region'],
           availability_zone: rds['availability_zone'],
           sec_availability_zone: rds['sec_availability_zone'],
           tagKeyValue:(tagKeyValue.slice(2)),
-          dbInstance_Identifier: rds['dbInstance_Identifier'],
-          storage_Encrypted: storage_Encrypted,
+          db_instance_identifier: rds['db_instance_identifier'],
+          storage_encrypted: storage_encrypted,
           db_instance_status: rds['db_instance_status'],
-          dbCluster_Identifier: rds['dbCluster_Identifier'],
-          delete_Protection: delete_Protection		  
+          db_cluster_identifier: rds['db_cluster_identifier'],
+          delete_protection: delete_protection		  
         })
       }
     }
@@ -384,23 +263,28 @@ end
 ###############################################################################
 
 policy "policy_rds_instance_list" do
-  validate $ds_rds_publicly_accessible_instance_map do
+  validate_each $ds_rds_publicly_accessible_instance_map do
     summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Publicly Accessible RDS Instances Found in AWS"
     detail_template <<-EOS
 # List of Publicly Accessible RDS Instances
-| DB_Instance_Identifier | Region | Availability_Zone | Secondary_Availability_Zone | Enable_Encryption  | DB_Engine_Name | DB_Instance_Status | Delete Protection Enabled | TAG_Value |
+| DB_Instance_Identifier | Region | Availability_Zone | Secondary_Availability_Zone | Enable_Encryption  | DB_Engine_Name | DB_Instance_Status | Delete_Protection_Enabled | TAG_Value |
 | ---------------------- | ------ | ----------------- | ----------------------------| ------------------ | ---------------| -------------------| --------------------------| ----------|
 {{ range data -}}
-| {{.dbInstance_Identifier}} | {{ .region }} | {{ .availability_zone }} |  {{ .sec_availability_zone }} |{{ .storage_Encrypted }} | {{ .dbName }} | {{ .db_instance_status }} | {{.delete_Protection}} | {{.tagKeyValue}} |
+| {{.db_instance_identifier}} | {{ .region }} | {{ .availability_zone }} |  {{ .sec_availability_zone }} |{{ .storage_encrypted }} | {{ .db_engine_name }} | {{ .db_instance_status }} | {{.delete_protection}} | {{.tagKeyValue}} |
 {{ end -}}
-###### Note: Kindly refer 'Enable Delete Action' section in the [README](https://github.com/rightscale/policy_templates/tree/master/security/aws/rds_publicly_accessible) file to perform delete operation.
+###### Note: Please refer to 'Enable Delete Action' section in the [README](https://github.com/rightscale/policy_templates/tree/master/security/aws/rds_publicly_accessible) file to perform delete operation.
     EOS
     escalate $report_publicly_accessible_RDS_instances
     escalate $modify_publicly_accessible_RDS_instance_approval
-    #uncomment (remove '#') in the below line to enable Delete action.
+    #Uncomment below five lines (remove '#') to enable Delete action.
     #escalate $delete_publicly_accessible_RDS_instances_approval
-    check eq(size(data),0)
-  end
+    #check logic_or(
+    # eq(val(item, "delete_protection"), "YES"),
+    # ne(val(item, "db_instance_status"), "available")
+    #)
+    check eq(val(item, "publicly_accessible"), "false")
+    #And comment above line (add '#' at beginning) when you enable Delete action.
+    end
 end
 
 ###############################################################################
@@ -429,9 +313,9 @@ escalation "delete_publicly_accessible_RDS_instances_approval" do
     label "Approve Resource Deletion"
     description "Approve escalation to run RightScale Cloud Workflow to delete publicly accessible RDS-instances"
     parameter "approval_reason" do
-    type "string"
-    label "Reason for Approval"
-    description "Note: RDS Instances with 'DB Instance Status' other than 'Available' state and instances with delete Protection enabled cannot be deleted"
+      type "string"
+      label "Reason for Approval"
+      description "Note: RDS Instances with 'DB Instance Status' other than 'Available' state and instances with delete Protection enabled cannot be deleted"
     end
   end
   run "delete_publicly_acessible_RDS_instances", data
@@ -448,7 +332,7 @@ define remove_public_access_RDS($data) return $all_responses do
   foreach $item in $data do
    sub on_error: skip do
     $response = http_get(
-       url: "https://rds."+$item["region"]+".amazonaws.com/?Action=ModifyDBInstance&Version=2014-10-31&PubliclyAccessible=false&DBInstanceIdentifier="+$item["dbInstance_Identifier"],
+       url: "https://rds."+$item["region"]+".amazonaws.com/?Action=ModifyDBInstance&Version=2014-10-31&PubliclyAccessible=false&DBInstanceIdentifier="+$item["db_instance_identifier"],
        "signature": { type: "aws" }
     )
     $all_responses << $response
@@ -465,33 +349,35 @@ define delete_publicly_acessible_RDS_instances($data) return $all_responses do
   $all_responses = []
   foreach $item in $data do
     sub on_error: skip do
-      if ($item['dbCluster_Identifier'] != null) && ($item["delete_Protection"] == 'No')
+      if ($item['db_cluster_identifier'] != null)
        #Creating Cluster snapshot manually Since DB instance snapshot cannot be created directly for Aurora cluster DB instance.
         $create_cluster_snapshot = http_get(
-          url: "https://rds."+$item["region"]+".amazonaws.com/?Action=CreateDBClusterSnapshot&Version=2014-10-31&DBClusterIdentifier="+$item["dbCluster_Identifier"]+"&DBClusterSnapshotIdentifier="+$item["dbCluster_Identifier"]+"-finalSnapshot",
+          url: "https://rds."+$item["region"]+".amazonaws.com/?Action=CreateDBClusterSnapshot&Version=2014-10-31&DBClusterIdentifier="+$item["db_cluster_identifier"]+"&DBClusterSnapshotIdentifier="+$item["db_cluster_identifier"]+"-finalSnapshot",
           "signature": { type: "aws" }
         )
         $status = $create_cluster_snapshot['body']['CreateDBClusterSnapshotResponse']['CreateDBClusterSnapshotResult']['DBClusterSnapshot']['Status']
 
         $statusCheckCount = 0
-        while ($status != "available") && ($statusCheckCount < 10) do
+        while ($status != "available") && ($statusCheckCount < 30) do
           sleep(30)
           $describe_cluster_snapshot = http_get(
-            url: "https://rds."+$item["region"]+".amazonaws.com/?Action=DescribeDBClusterSnapshots&Version=2014-10-31&DBClusterSnapshotIdentifier="+$item["dbCluster_Identifier"]+"-finalSnapshot",
+            url: "https://rds."+$item["region"]+".amazonaws.com/?Action=DescribeDBClusterSnapshots&Version=2014-10-31&DBClusterSnapshotIdentifier="+$item["db_cluster_identifier"]+"-finalSnapshot",
             "signature": { type: "aws" }
           )
           $status = $describe_cluster_snapshot['body']['DescribeDBClusterSnapshotsResponse']['DescribeDBClusterSnapshotsResult']['DBClusterSnapshots']['DBClusterSnapshot']['Status']
           $statusCheckCount = $statusCheckCount + 1
         end
 
+        if $status == "available"
+          $response = http_get(
+            url: "https://rds."+$item["region"]+".amazonaws.com/?Action=DeleteDBInstance&Version=2014-10-31&DeleteAutomatedBackups=false&DBInstanceIdentifier="+ $item["db_instance_identifier"],
+            "signature": { type: "aws" }
+          )
+    end
+      else
+        #Delete non-Aurora DB instances were a DB snapshot gets created with name '<--db_instance_identifier-->-finalSnapshot' Ex mySQL-DBinstance--finalSnapshot before deleting DB instance.
         $response = http_get(
-          url: "https://rds."+$item["region"]+".amazonaws.com/?Action=DeleteDBInstance&Version=2014-10-31&DeleteAutomatedBackups=false&DBInstanceIdentifier="+ $item["dbInstance_Identifier"],
-          "signature": { type: "aws" }
-        )
-      elsif $item["delete_Protection"] == 'No'
-        #Delete non-Aurora DB instances were a DB snapshot gets created with name '<--dbInstance_Identifier-->-finalSnapshot' Ex mySQL-DBinstance--finalSnapshot before deleting DB instance.
-        $response = http_get(
-          url: "https://rds."+$item["region"]+".amazonaws.com/?Action=DeleteDBInstance&Version=2014-10-31&DeleteAutomatedBackups=false&DBInstanceIdentifier="+ $item["dbInstance_Identifier"]+"&FinalDBSnapshotIdentifier="+$item["dbInstance_Identifier"]+"-finalSnapshot",
+          url: "https://rds."+$item["region"]+".amazonaws.com/?Action=DeleteDBInstance&Version=2014-10-31&DeleteAutomatedBackups=false&DBInstanceIdentifier="+ $item["db_instance_identifier"]+"&FinalDBSnapshotIdentifier="+$item["db_instance_identifier"]+"-finalSnapshot",
           "signature": { type: "aws" }
         )
       end

--- a/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt
+++ b/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt
@@ -1,0 +1,499 @@
+name "AWS Publicly Accessible RDS Instances"
+rs_pt_ver 20180301
+type "policy"
+short_description "Report and remediate any Relational Database Service (RDS) instances that are publicly accessible. \n See the [README](https://github.com/rightscale/policy_templates/tree/master/security/aws/rds_publicly_accessible) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
+long_description "Version: 1.0"
+category "Security"
+severity "high"
+
+###############################################################################
+# Permissions
+###############################################################################
+
+permission "perm_read_creds" do
+  actions   "rs_cm.show_sensitive","rs_cm.index_sensitive"
+  resources "rs_cm.credentials"
+end
+
+###############################################################################
+# User inputs
+###############################################################################
+
+parameter "param_email" do
+  type "list"
+  label "Email addresses to notify"
+  description "Email addresses of the recipients you wish to notify when new incidents are created"
+end
+
+parameter "param_exclude_tags" do
+  type "list"
+  label "Tags to ignore"
+  description "List of tags that will exclude resources from being evaluated by this policy. Multiple tags are evaluated as an 'OR' condition. Tag keys or key/value pairs can be listed. Example: 'test,env=dev'"
+end
+
+###############################################################################
+# Authentication
+###############################################################################
+
+auth "auth_us_east_1", type: "aws" do
+  version "4"
+  service "rds"
+  region 'us-east-1'
+  access_key cred("AWS_ACCESS_KEY_ID")
+  secret_key cred("AWS_SECRET_ACCESS_KEY")
+end
+
+auth "auth_us_east_2", type: "aws" do
+  version "4"
+  service "rds"
+  region 'us-east-2'
+  access_key cred("AWS_ACCESS_KEY_ID")
+  secret_key cred("AWS_SECRET_ACCESS_KEY")
+end
+
+auth "auth_us_west_1", type: "aws" do
+  version "4"
+  service "rds"
+  region 'us-west-1'
+  access_key cred("AWS_ACCESS_KEY_ID")
+  secret_key cred("AWS_SECRET_ACCESS_KEY")
+end
+
+auth "auth_us_west_2", type: "aws" do
+  version "4"
+  service "rds"
+  region 'us-west-2'
+  access_key cred("AWS_ACCESS_KEY_ID")
+  secret_key cred("AWS_SECRET_ACCESS_KEY")
+end
+
+auth "auth_ap_south_1", type: "aws" do
+  version 4
+  service "rds"
+  region 'ap-south-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_ap_northeast_2", type: "aws" do
+  version 4
+  service "rds"
+  region 'ap-northeast-2'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_ap_southeast_1", type: "aws" do
+  version 4
+  service "rds"
+  region 'ap-southeast-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_ap_southeast_2", type: "aws" do
+  version 4
+  service "rds"
+  region 'ap-southeast-2'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_ap_northeast_1", type: "aws" do
+  version 4
+  service "rds"
+  region 'ap-northeast-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_ca_central_1", type: "aws" do
+  version 4
+  service "rds"
+  region 'ca-central-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_eu_central_1", type: "aws" do
+  version 4
+  service "rds"
+  region 'eu-central-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_eu_west_1", type: "aws" do
+  version 4
+  service "rds"
+  region 'eu-west-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_eu_west_2", type: "aws" do
+  version 4
+  service "rds"
+  region 'eu-west-2'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_eu_west_3", type: "aws" do
+  version 4
+  service "rds"
+  region 'eu-west-3'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_sa_east_1", type: "aws" do
+  version 4
+  service "rds"
+  region 'sa-east-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+auth "auth_eu_north_1", type: "aws" do
+  version 4
+  service "rds"
+  region 'eu-north-1'
+  access_key cred('AWS_ACCESS_KEY_ID')
+  secret_key cred('AWS_SECRET_ACCESS_KEY')
+end
+
+###############################################################################
+# Pagination
+###############################################################################
+
+pagination "rds_pagination" do
+  get_page_marker do
+    body_path "DescribeDBInstancesResult.NextMarker"
+  end
+  set_page_marker do
+    query "Marker"
+  end
+end
+
+###############################################################################
+# Datasources
+###############################################################################
+
+#Generates list of Regions.
+datasource "ds_regions_list" do
+  run_script $js_regions_map
+end
+
+#To get list of All RDS Instances.
+datasource "ds_rds_instances_list" do
+  iterate $ds_regions_list
+  request do
+    run_script $js_rds_list, val(iter_item,"region")
+  end
+  result do
+   encoding "json"
+    collect jmes_path(response, "DescribeDBInstancesResponse.DescribeDBInstancesResult.DBInstances[*]") do
+      field "dbInstanceArn", jmes_path(col_item, "DBInstanceArn")
+      field "dbInstance_Identifier", jmes_path(col_item, "DBInstanceIdentifier")
+      field "publicly_Accessible", jmes_path(col_item, "PubliclyAccessible")
+      field "storage_Encrypted", jmes_path(col_item, "StorageEncrypted")
+      field "dbName", jmes_path(col_item, "Engine")
+      field "delete_Protection", jmes_path(col_item, "DeletionProtection")
+      field "availability_zone", jmes_path(col_item, "AvailabilityZone")
+      field "sec_availability_zone", jmes_path(col_item, "SecondaryAvailabilityZone")
+      field "db_instance_status", jmes_path(col_item,"DBInstanceStatus")
+      field "region", val(iter_item,"region")
+      field "dbCluster_Identifier", jmes_path(col_item,"DBClusterIdentifier")
+    end
+  end
+end
+
+#Get respective tags for all RDS instances
+datasource "ds_rds_list_with_tags" do
+  iterate $ds_rds_instances_list
+  request do
+    run_script $js_rds_list_with_tags, val(iter_item,"region"), val(iter_item, "dbInstanceArn")
+  end
+  result do
+    encoding "json"
+    collect jmes_path(response, "ListTagsForResourceResponse.ListTagsForResourceResult") do
+      field "tags" do
+        collect jmes_path(col_item, "TagList") do
+          field "tagKey", jmes_path(col_item, "Key")
+          field "tagValue", jmes_path(col_item, "Value")
+        end
+      end
+      field "dbInstanceArn", val(iter_item, "dbInstanceArn")
+      field "dbInstance_Identifier", val(iter_item, "dbInstance_Identifier")
+      field "publicly_Accessible", val(iter_item, "publicly_Accessible")
+      field "storage_Encrypted", val(iter_item, "storage_Encrypted")
+      field "delete_Protection", val(iter_item, "delete_Protection")
+      field "region", val(iter_item,"region")
+      field "dbName", val(iter_item,"dbName")
+      field "availability_zone", val(iter_item, "availability_zone")
+      field "sec_availability_zone", val(iter_item, "sec_availability_zone")
+      field "db_instance_status", val(iter_item,"db_instance_status")
+      field "dbCluster_Identifier", val(iter_item,"dbCluster_Identifier")
+    end
+  end
+end
+
+datasource "ds_rds_publicly_accessible_instance_map" do
+  run_script $js_rds_filter_map, $ds_rds_list_with_tags, $param_exclude_tags
+end
+
+###############################################################################
+# Scripts
+###############################################################################
+
+script "js_regions_map", type: "javascript" do
+  result "regions_map"
+  code <<-EOS
+    var regions_map=[]
+    regions_map.push({"region": "us-east-1"}, {"region": "us-east-2"}, {"region": "us-west-1"}, {"region": "us-west-2"}, {"region": "ap-south-1"}, {"region": "ap-northeast-2"}, {"region": "ap-southeast-1"}, {"region": "ap-southeast-2"}, {"region": "ap-northeast-1"}, {"region": "ca-central-1"}, {"region": "eu-central-1"}, {"region": "eu-west-1"}, {"region": "eu-west-2"}, {"region": "eu-west-3"}, {"region": "sa-east-1"}, {"region": "eu-north-1"})
+  EOS
+end
+
+#https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBInstances.html
+script "js_rds_list", type: "javascript" do
+  parameters "region"
+  result "results"
+  code <<-EOS
+    results = {
+      auth: "auth_"+region.replace(/-/g,"_"),
+      host: 'rds.'+region+'.amazonaws.com',
+      path: '/',
+      pagination: "rds_list_pagination",
+      query_params: {
+        "Action": "DescribeDBInstances",
+        "Version": "2014-10-31",
+      },
+      headers: {
+        "Accept": "application/json"
+      }
+    }
+  EOS
+end
+
+#https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ListTagsForResource.html
+script "js_rds_list_with_tags", type: "javascript" do
+  parameters "region", "dbInstanceArn"
+  result "request"
+  code <<-EOS
+    request = {
+      auth: 'auth_'+region.replace(/-/g,"_"),
+      host: 'rds.'+region+'.amazonaws.com',
+      path: '/',
+      verb: 'GET',
+      query_params: {
+        "Action": "ListTagsForResource",
+        "Version": "2014-10-31",
+        "ResourceName": dbInstanceArn,
+      },
+      headers: {
+        "Accept": "application/json"
+      }
+    }
+  EOS
+end
+
+#Process the response data, check for the tags and generate a list of RDS instances that are publicly accessible
+script "js_rds_filter_map", type: "javascript" do
+  parameters "ds_rds_list_with_tags", "param_exclude_tags"
+  result "content"
+  code <<-EOS
+    var param_exclude_tags_lower=[];
+    for(var j=0; j < param_exclude_tags.length; j++){
+      param_exclude_tags_lower[j]=param_exclude_tags[j].toString().toLowerCase();
+    }
+
+    var content=[]
+    for(var i=0; i<ds_rds_list_with_tags.length; i++){
+      rds=ds_rds_list_with_tags[i]
+
+      //Check, if the tag present in entered param_exclude_tags, ignore the RDS instance if the tag matches/present.
+      var tags = rds['tags']
+      var isTagMatched=false
+      var tagKeyValue=""
+      for(var j=0; j < tags.length; j++){
+        tag = tags[j]
+        if((param_exclude_tags_lower.indexOf((tag['tagKey']).toLowerCase()) !== -1) || (param_exclude_tags_lower.indexOf((tag['tagKey']+'='+tag['tagValue']).toLowerCase()) !== -1)){
+          isTagMatched = true;
+        }
+        // Constructing tags with comma separated to display in detail_template
+        if((tag['tagValue']).length > 0){
+          tagKeyValue = tagKeyValue + ', '+ tag['tagKey']+'='+tag['tagValue']
+        }else{
+          tagKeyValue = tagKeyValue + ', '+ tag['tagKey']
+        }
+      }
+
+      var storage_Encrypted = rds['storage_Encrypted'];
+      if(storage_Encrypted === true){
+        storage_Encrypted = 'Yes';
+      }else{
+        storage_Encrypted = 'No';
+      }  
+      var delete_Protection = rds['delete_Protection'];
+      if(delete_Protection === true){
+        delete_Protection = 'Yes';
+      }else{
+        delete_Protection = 'No';
+      }
+
+      //If the RDS instance tag does not match with entered param_exclude_tags, then check if RDS instance is Publicly Accessible
+      if(!(isTagMatched) && (rds['publicly_Accessible']) === true){
+        content.push({
+          dbInstanceArn: rds['dbInstanceArn'],
+          dbName: rds['dbName'],
+          region: rds['region'],
+          availability_zone: rds['availability_zone'],
+          sec_availability_zone: rds['sec_availability_zone'],
+          tagKeyValue:(tagKeyValue.slice(2)),
+          dbInstance_Identifier: rds['dbInstance_Identifier'],
+          storage_Encrypted: storage_Encrypted,
+          db_instance_status: rds['db_instance_status'],
+          dbCluster_Identifier: rds['dbCluster_Identifier'],
+          delete_Protection: delete_Protection		  
+        })
+      }
+    }
+  EOS
+end
+
+###############################################################################
+# Policy
+###############################################################################
+
+policy "policy_rds_instance_list" do
+  validate $ds_rds_publicly_accessible_instance_map do
+    summary_template "{{ rs_project_name }} (Account ID: {{ rs_project_id }}): {{ len data }} Publicly Accessible RDS Instances Found in AWS"
+    detail_template <<-EOS
+# List of Publicly Accessible RDS Instances
+| DB_Instance_Identifier | Region | Availability_Zone | Secondary_Availability_Zone | Enable_Encryption  | DB_Engine_Name | DB_Instance_Status | Delete Protection Enabled | TAG_Value |
+| ---------------------- | ------ | ----------------- | ----------------------------| ------------------ | ---------------| -------------------| --------------------------| ----------|
+{{ range data -}}
+| {{.dbInstance_Identifier}} | {{ .region }} | {{ .availability_zone }} |  {{ .sec_availability_zone }} |{{ .storage_Encrypted }} | {{ .dbName }} | {{ .db_instance_status }} | {{.delete_Protection}} | {{.tagKeyValue}} |
+{{ end -}}
+###### Note: Kindly refer 'Enable Delete Action' section in the [README](https://github.com/rightscale/policy_templates/tree/master/security/aws/rds_publicly_accessible) file to perform delete operation.
+    EOS
+    escalate $report_publicly_accessible_RDS_instances
+    escalate $modify_publicly_accessible_RDS_instance_approval
+	#Kindly uncomment (remove '#') in the below line to enable Delete action.
+    #escalate $delete_publicly_accessible_RDS_instances_approval
+    check eq(size(data),0)
+  end
+end
+
+###############################################################################
+# Escalation
+###############################################################################
+
+escalation "report_publicly_accessible_RDS_instances" do
+  email $param_email
+end
+
+escalation "modify_publicly_accessible_RDS_instance_approval" do
+  request_approval  do
+    label "Approve RDS Public Access Rule Config Change"
+    description "Approve escalation to run RightScale Cloud Workflow to public access rule config change for RDS instances"
+    parameter "approval_reason" do
+      type "string"
+      label "Reason for Approval"
+      description "Note: 'Public Access Config' will be modified for the RDS instances that has 'Available' state and can not be modified 'public access config' for other states like stopped, stopping & modifying etc.."
+    end
+  end
+  run "remove_public_access_RDS", data
+end
+
+escalation "delete_publicly_accessible_RDS_instances_approval" do
+  request_approval  do
+    label "Approve Resource Deletion"
+    description "Approve escalation to run RightScale Cloud Workflow to delete publicly accessible RDS-instances"
+    parameter "approval_reason" do
+    type "string"
+    label "Reason for Approval"
+    description "Note: RDS Instances with 'DB Instance Status' other than 'Available' state and instances with delete Protection enabled cannot be deleted"
+    end
+  end
+  run "delete_publicly_acessible_RDS_instances", data
+end
+
+###############################################################################
+# Cloud Workflow
+###############################################################################
+
+#https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBInstance.html
+define remove_public_access_RDS($data) return $all_responses do
+  $$debug=true
+  $all_responses = []
+  foreach $item in $data do
+   sub on_error: skip do
+    $response = http_get(
+       url: "https://rds."+$item["region"]+".amazonaws.com/?Action=ModifyDBInstance&Version=2014-10-31&PubliclyAccessible=false&DBInstanceIdentifier="+$item["dbInstance_Identifier"],
+       "signature": { type: "aws" }
+    )
+    $all_responses << $response
+    call sys_log('RDS instance config change response',to_s($response))
+    end
+  end
+end
+
+#https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteDBInstance.html
+#https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBClusterSnapshot.html
+#https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBClusterSnapshots.html
+define delete_publicly_acessible_RDS_instances($data) return $all_responses do
+  $$debug=true
+  $all_responses = []
+  foreach $item in $data do
+    sub on_error: skip do
+
+      if ($item['dbCluster_Identifier'] != null) && ($item["delete_Protection"] == 'No')
+       #Creating Cluster snapshot manually Since DB instance snapshot cannot be created directly for Aurora cluster DB instance.
+        $create_cluster_snapshot = http_get(
+          url: "https://rds."+$item["region"]+".amazonaws.com/?Action=CreateDBClusterSnapshot&Version=2014-10-31&DBClusterIdentifier="+$item["dbCluster_Identifier"]+"&DBClusterSnapshotIdentifier="+$item["dbCluster_Identifier"]+"-finalSnapshot",
+          "signature": { type: "aws" }
+        )
+        $status = $create_cluster_snapshot['body']['CreateDBClusterSnapshotResponse']['CreateDBClusterSnapshotResult']['DBClusterSnapshot']['Status']
+
+        $statusCheckCount = 0
+        while ($status != "available") && ($statusCheckCount < 10) do
+          sleep(30)
+          $describe_cluster_snapshot = http_get(
+            url: "https://rds."+$item["region"]+".amazonaws.com/?Action=DescribeDBClusterSnapshots&Version=2014-10-31&DBClusterSnapshotIdentifier="+$item["dbCluster_Identifier"]+"-finalSnapshot",
+            "signature": { type: "aws" }
+          )
+          $status = $describe_cluster_snapshot['body']['DescribeDBClusterSnapshotsResponse']['DescribeDBClusterSnapshotsResult']['DBClusterSnapshots']['DBClusterSnapshot']['Status']
+          $statusCheckCount = $statusCheckCount + 1
+        end
+
+        $response = http_get(
+          url: "https://rds."+$item["region"]+".amazonaws.com/?Action=DeleteDBInstance&Version=2014-10-31&DeleteAutomatedBackups=false&DBInstanceIdentifier="+ $item["dbInstance_Identifier"],
+          "signature": { type: "aws" }
+        )
+      elsif $item["delete_Protection"] == 'No'
+        #Delete non-Aurora DB instances were a DB snapshot gets created with name '<--dbInstance_Identifier-->-finalSnapshot' Ex mySQL-DBinstance--finalSnapshot before deleting DB instance.
+        $response = http_get(
+          url: "https://rds."+$item["region"]+".amazonaws.com/?Action=DeleteDBInstance&Version=2014-10-31&DeleteAutomatedBackups=false&DBInstanceIdentifier="+ $item["dbInstance_Identifier"]+"&FinalDBSnapshotIdentifier="+$item["dbInstance_Identifier"]+"-finalSnapshot",
+          "signature": { type: "aws" }
+        )
+      end
+      $all_responses << $response
+      call sys_log('RDS instance delete response',to_s($response))
+    end
+  end
+end
+
+define sys_log($subject, $detail) do
+  if $$debug
+    rs_cm.audit_entries.create(
+      notify: "None",
+      audit_entry: {
+        auditee_href: @@account,
+        summary: "AWS Publicly Accessible RDS Instances Policy "+ $subject,
+        detail: $detail
+      }
+    )
+  end
+end

--- a/security/aws/rds_publicly_accessible/CHANGELOG.md
+++ b/security/aws/rds_publicly_accessible/CHANGELOG.md
@@ -1,0 +1,4 @@
+v1.0
+-----
+- initial release
+

--- a/security/aws/rds_publicly_accessible/README.md
+++ b/security/aws/rds_publicly_accessible/README.md
@@ -1,0 +1,68 @@
+## AWS Publicly Accessible RDS Instances
+ 
+### What it does
+This policy checks all Relational Database Service (RDS) instances and reports on any that are publicly accessible. When such an instance is detected, the user can choose to disable the publicly accessible option and the user can also choose to delete by enabling 'delete action' option as mentioned in Enable delete action section below.
+ 
+### Functional Details
+ 
+When a publicly accessible RDS instance is detected, an email action is triggered automatically to notify the specified users of the incident. Users then have an option to modify configuration after manual approval, and even Users can perform delete action if required. 
+- *remove public access rule* - modifies the configuration of the RDS instance by disabling the public access rule
+ 
+#### Input Parameters
+ 
+- *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
+- *Ignore tags* - RDS instances with any of these tags will be ignored 
+ 
+### Required RightScale Roles
+ 
+- policy_manager
+- admin or credential_viewer
+
+### AWS Required Permissions
+
+This policy requires permissions to describe AWS RDS instances, tags, modify and delete instances.
+The Cloud Management Platform automatically creates two Credentials when connecting AWS to Cloud Management; AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. The IAM user credentials contained in those credentials will require the following permissions:
+
+```javascript
+{
+  "Version": "2014-10-31",
+  "Statement":[{
+  "Effect":"Allow",
+  "Action":["rds:DescribeDBInstances",
+            "rds:ListTagsForResource",
+            "rds:ModifyDBInstance",
+            "rds:CreateDBClusterSnapshot",
+            "rds:DescribeDBClusterSnapshots",			
+            "rds:DeleteDBInstance"],
+    "Resource":"*"
+    }
+  ]
+}
+```
+
+### Supported Clouds
+ 
+- AWS
+ 
+### Cost
+ 
+This Policy Template does not incur any cloud costs.
+
+
+### Enable delete action
+
+Perform below steps to enable delete action.
+
+- Edit the file [AWS_Publicly_Accessible_RDS_Instances] (https://github.com/rightscale/policy_templates/tree/master/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt)
+- uncomment the line which contains 'escalate $delete_publicly_accessible_RDS_instances_approval' and save the changes.
+- upload the modified file and apply the policy.
+
+Note: 
+- RDS Instances with 'DB Instance Status' other than 'Available' and RDS instances with 'delete Protection enabled' cannot be deleted
+- RDS instances with 'DB Instance Status' other than 'Available' can not be modified.
+- When delete action is performed, DB snapshot gets created with name '<--DB_Instance_Identifier-->-finalSnapshot' Ex mySQL-DBinstance-finalSnapshot before deleting DB instance.
+- For Aurora instance, policy creates Cluster snapshot Since DB instance snapshot cannot be created directly.
+
+
+
+

--- a/security/aws/rds_publicly_accessible/README.md
+++ b/security/aws/rds_publicly_accessible/README.md
@@ -8,7 +8,7 @@ This policy checks all Relational Database Service (RDS) instances and reports o
 When a publicly accessible RDS instance is detected, an email action is triggered automatically to notify the specified users of the incident. Users then have an option to modify configuration after manual approval, and even Users can perform delete action if required. 
 - *remove public access rule* - modifies the configuration of the RDS instance by disabling the public access rule
  
-#### Input Parameters
+### Input Parameters
  
 - *Email addresses of the recipients you wish to notify* - A list of email addresses to notify
 - *Ignore tags* - RDS instances with any of these tags will be ignored 
@@ -53,7 +53,7 @@ This Policy Template does not incur any cloud costs.
 
 Perform below steps to enable delete action.
 
-- Edit the file [AWS_Publicly_Accessible_RDS_Instances] (https://github.com/rightscale/policy_templates/tree/master/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt)
+- Edit the file [AWS_Publicly_Accessible_RDS_Instances](https://github.com/rightscale/policy_templates/tree/master/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt)
 - uncomment the line which contains 'escalate $delete_publicly_accessible_RDS_instances_approval' and save the changes.
 - upload the modified file and apply the policy.
 

--- a/security/aws/rds_publicly_accessible/README.md
+++ b/security/aws/rds_publicly_accessible/README.md
@@ -20,7 +20,7 @@ When a publicly accessible RDS instance is detected, an email action is triggere
 
 ### AWS Required Permissions
 
-This policy requires permissions to describe AWS RDS instances, tags, modify and delete instances.
+This policy requires permissions to describe AWS RDS instances, list RDS tags, modify RDS instances and delete RDS instances.
 The Cloud Management Platform automatically creates two Credentials when connecting AWS to Cloud Management; AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. The IAM user credentials contained in those credentials will require the following permissions:
 
 ```javascript
@@ -54,15 +54,22 @@ This Policy Template does not incur any cloud costs.
 Perform below steps to enable delete action.
 
 - Edit the file [AWS_Publicly_Accessible_RDS_Instances](https://github.com/rightscale/policy_templates/tree/master/security/aws/rds_publicly_accessible/AWS_Publicly_Accessible_RDS_Instances.pt)
-- uncomment the line which contains 'escalate $delete_publicly_accessible_RDS_instances_approval' and save the changes.
+- uncomment below mentioned lines
+```javascript
+   escalate $delete_publicly_accessible_RDS_instances_approval
+	check logic_or(
+      eq(val(item, "delete_protection"), "YES"),
+      ne(val(item, "db_instance_status"), "available")
+    )
+```	
+- And comment the line which contains 'check eq(val(item, "publicly_accessible"), "false")', save the changes.
 - upload the modified file and apply the policy.
 
 Note: 
-- RDS Instances with 'DB Instance Status' other than 'Available' and RDS instances with 'delete Protection enabled' cannot be deleted
+- RDS Instances with 'DB Instance Status' other than 'Available' and RDS instances with 'Delete Protection Enabled' cannot be deleted
 - RDS instances with 'DB Instance Status' other than 'Available' can not be modified.
-- When delete action is performed, DB snapshot gets created with name '<--DB_Instance_Identifier-->-finalSnapshot' Ex mySQL-DBinstance-finalSnapshot before deleting DB instance.
+- When delete action is performed, DB snapshot gets created with name '<--RDS Instance Name-->-finalSnapshot' Ex mySQL-DBinstance-finalSnapshot before deleting DB instance.
 - For Aurora instance, policy creates Cluster snapshot Since DB instance snapshot cannot be created directly.
-
 
 
 


### PR DESCRIPTION
Initial release for POL-35 AWS Publicly Accessible RDS Instances

### Description

This policy checks all Relational Database Service (RDS) instances and reports on any that are publicly accessible. When such an instance is detected, the user can choose to disable the publicly accessible option and the user can also choose to delete by enabling 'delete action' option as mentioned in Enable delete action section below.

### Issues Resolved

When a publicly accessible RDS instance is detected, an email action is triggered automatically to notify the specified users of the incident. Users then have an option to modify configuration after manual approval, and even Users can perform delete action if required. 
- *remove public access rule* - modifies the configuration of the RDS instance by disabling the public access rule

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD

### Running Template Link:
https://governance.rightscale.com/org/1105/projects/60073/policy-incidents/5cdd360938e25e007152d7c0

### Screenshot:
![image](https://user-images.githubusercontent.com/47382786/57852997-3ff80f80-7802-11e9-8b14-05bc499e1ea4.png)

