### PR TITLE
Fix for Azure API Client Secret Encoding

### DIFF
--- a/compliance/azure/azure_disallowed_regions/CHANGELOG.md
+++ b/compliance/azure/azure_disallowed_regions/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.1
+----
+- url encode client secret
+
 v1.0
 -----
 - initial release

--- a/compliance/azure/azure_disallowed_regions/azure_disallowed_regions.pt
+++ b/compliance/azure/azure_disallowed_regions/azure_disallowed_regions.pt
@@ -2,7 +2,7 @@ name "Azure Disallowed Regions"
 rs_pt_ver 20180301
 type "policy"
 short_description "A policy that discovers all Azure resources that have been provisioned in unapproved regions and optionally deletes them. See the [README](https://github.com/rightscale/policy_templates/tree/master/compliance/azure/azure_disallowed_regions) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.0"
+long_description "Version: 1.1"
 severity "medium"
 category "Compliance"
 
@@ -157,7 +157,7 @@ end
 define get_access_token($param_azure_tenant_id) return $access_token do
 
   $client_id = cred("AZURE_APPLICATION_ID")
-  $client_secret = cred("AZURE_APPLICATION_KEY")
+  call url_encode(cred("AZURE_APPLICATION_KEY")) retrieve $client_secret
 
   $body_string = "grant_type=client_credentials&resource=https://management.core.windows.net/&client_id="+$client_id+"&client_secret="+$client_secret
 
@@ -173,4 +173,27 @@ define get_access_token($param_azure_tenant_id) return $access_token do
   $auth_response_body = $auth_response["body"]
   $access_token = $auth_response_body["access_token"]
 
+end
+
+define url_encode($string) return $encoded_string do
+  $encoded_string = $string
+  $encoded_string = gsub($encoded_string, " ", "%20")
+  $encoded_string = gsub($encoded_string, "!", "%21")
+  $encoded_string = gsub($encoded_string, "#", "%23")
+  $encoded_string = gsub($encoded_string, "$", "%24")
+  $encoded_string = gsub($encoded_string, "&", "%26")
+  $encoded_string = gsub($encoded_string, "'", "%27")
+  $encoded_string = gsub($encoded_string, "(", "%28")
+  $encoded_string = gsub($encoded_string, ")", "%29")
+  $encoded_string = gsub($encoded_string, "*", "%2A")
+  $encoded_string = gsub($encoded_string, "+", "%2B")
+  $encoded_string = gsub($encoded_string, ",", "%2C")
+  $encoded_string = gsub($encoded_string, "/", "%2F")
+  $encoded_string = gsub($encoded_string, ":", "%3A")
+  $encoded_string = gsub($encoded_string, ";", "%3B")
+  $encoded_string = gsub($encoded_string, "=", "%3D")
+  $encoded_string = gsub($encoded_string, "?", "%3F")
+  $encoded_string = gsub($encoded_string, "@", "%40")
+  $encoded_string = gsub($encoded_string, "[", "%5B")
+  $encoded_string = gsub($encoded_string, "]", "%5D")
 end

--- a/compliance/tags/azure_rg_tags/CHANGELOG.md
+++ b/compliance/tags/azure_rg_tags/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Azure: Tag Resources with Resource Group Name
+v1.1
+----
+- url encode client secret
 
 v1.0
 -----

--- a/compliance/tags/azure_rg_tags/azure_resource_group_tags.pt
+++ b/compliance/tags/azure_rg_tags/azure_resource_group_tags.pt
@@ -2,7 +2,7 @@ name "Azure: Tag Resources with Resource Group Name"
 rs_pt_ver 20180301
 type "policy"
 short_description "Scan all resources in an Azure Subscription, raise an incident if any resources are not tagged with the name of their Resource Group, and remediate by tagging the resource. \n See the [README](https://github.com/rightscale/policy_templates/tree/master/compliance/tags/azure_rg_tags) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.0"
+long_description "Version: 1.1"
 severity "medium"
 category "Compliance"
 
@@ -248,7 +248,7 @@ end
 define get_access_token($param_azure_tenant_id) return $access_token do
 
   $client_id = cred("AZURE_APPLICATION_ID")
-  $client_secret = cred("AZURE_APPLICATION_KEY")
+  call url_encode(cred("AZURE_APPLICATION_KEY")) retrieve $client_secret
 
   $body_string = "grant_type=client_credentials&resource=https://management.core.windows.net/&client_id="+$client_id+"&client_secret="+$client_secret
 
@@ -266,16 +266,25 @@ define get_access_token($param_azure_tenant_id) return $access_token do
 
 end
 
-define start_debugging() do
-  if $$debugging == false || logic_and($$debugging != false, $$debugging != true)
-    initiate_debug_report()
-    $$debugging = true
-  end
-end
-
-define stop_debugging() do
-  if $$debugging == true
-    $$debug_report = complete_debug_report()
-    $$debugging = false
-  end
+define url_encode($string) return $encoded_string do
+  $encoded_string = $string
+  $encoded_string = gsub($encoded_string, " ", "%20")
+  $encoded_string = gsub($encoded_string, "!", "%21")
+  $encoded_string = gsub($encoded_string, "#", "%23")
+  $encoded_string = gsub($encoded_string, "$", "%24")
+  $encoded_string = gsub($encoded_string, "&", "%26")
+  $encoded_string = gsub($encoded_string, "'", "%27")
+  $encoded_string = gsub($encoded_string, "(", "%28")
+  $encoded_string = gsub($encoded_string, ")", "%29")
+  $encoded_string = gsub($encoded_string, "*", "%2A")
+  $encoded_string = gsub($encoded_string, "+", "%2B")
+  $encoded_string = gsub($encoded_string, ",", "%2C")
+  $encoded_string = gsub($encoded_string, "/", "%2F")
+  $encoded_string = gsub($encoded_string, ":", "%3A")
+  $encoded_string = gsub($encoded_string, ";", "%3B")
+  $encoded_string = gsub($encoded_string, "=", "%3D")
+  $encoded_string = gsub($encoded_string, "?", "%3F")
+  $encoded_string = gsub($encoded_string, "@", "%40")
+  $encoded_string = gsub($encoded_string, "[", "%5B")
+  $encoded_string = gsub($encoded_string, "]", "%5D")
 end

--- a/cost/azure/hybrid_use_benefit/CHANGELOG.md
+++ b/cost/azure/hybrid_use_benefit/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.1
+----
+- url encode client secret
+
 v1.0
 ----
 - initial release

--- a/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
+++ b/cost/azure/hybrid_use_benefit/azure_hybrid_use_benefit.pt
@@ -2,7 +2,7 @@ name "Azure Hybrid Use Benefit for Windows Server"
 rs_pt_ver 20180301
 type "policy"
 short_description "Identifies eligible instances not utilizing Azure Hybrid Use Benefit.  See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/azure/hybrid_use_benefit) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.0"
+long_description "Version: 1.1"
 severity "low"
 category "Cost"
 
@@ -196,7 +196,7 @@ end
 
 define get_access_token($param_azure_tenant_id) return $access_token do
   $client_id = cred("AZURE_APPLICATION_ID")
-  $client_secret = cred("AZURE_APPLICATION_KEY")
+  call url_encode(cred("AZURE_APPLICATION_KEY")) retrieve $client_secret
 
   $body_string = "grant_type=client_credentials&resource=https://management.core.windows.net/&client_id="+$client_id+"&client_secret="+$client_secret
 
@@ -211,4 +211,27 @@ define get_access_token($param_azure_tenant_id) return $access_token do
 
   $auth_response_body = $auth_response["body"]
   $access_token = $auth_response_body["access_token"]
+end
+
+define url_encode($string) return $encoded_string do
+  $encoded_string = $string
+  $encoded_string = gsub($encoded_string, " ", "%20")
+  $encoded_string = gsub($encoded_string, "!", "%21")
+  $encoded_string = gsub($encoded_string, "#", "%23")
+  $encoded_string = gsub($encoded_string, "$", "%24")
+  $encoded_string = gsub($encoded_string, "&", "%26")
+  $encoded_string = gsub($encoded_string, "'", "%27")
+  $encoded_string = gsub($encoded_string, "(", "%28")
+  $encoded_string = gsub($encoded_string, ")", "%29")
+  $encoded_string = gsub($encoded_string, "*", "%2A")
+  $encoded_string = gsub($encoded_string, "+", "%2B")
+  $encoded_string = gsub($encoded_string, ",", "%2C")
+  $encoded_string = gsub($encoded_string, "/", "%2F")
+  $encoded_string = gsub($encoded_string, ":", "%3A")
+  $encoded_string = gsub($encoded_string, ";", "%3B")
+  $encoded_string = gsub($encoded_string, "=", "%3D")
+  $encoded_string = gsub($encoded_string, "?", "%3F")
+  $encoded_string = gsub($encoded_string, "@", "%40")
+  $encoded_string = gsub($encoded_string, "[", "%5B")
+  $encoded_string = gsub($encoded_string, "]", "%5D")
 end

--- a/cost/azure/superseded_instance_types/CHANGELOG.md
+++ b/cost/azure/superseded_instance_types/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.2
+----
+- url encode client secret
+
 v1.1
 ----
 - fix readme link in description

--- a/cost/azure/superseded_instance_types/azure_superseded_instance_types.pt
+++ b/cost/azure/superseded_instance_types/azure_superseded_instance_types.pt
@@ -2,7 +2,7 @@ name "Azure Superseded Instance Types"
 rs_pt_ver 20180301
 type "policy"
 short_description "Discover disallowed instance types and resize to an approved instance type. See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/azure/superseded_instance_types) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.1"
+long_description "Version: 1.2"
 severity "medium"
 category "Cost"
 
@@ -289,7 +289,7 @@ end
 define get_access_token($param_azure_tenant_id) return $access_token do
 
   $client_id = cred("AZURE_APPLICATION_ID")
-  $client_secret = cred("AZURE_APPLICATION_KEY")
+  call url_encode(cred("AZURE_APPLICATION_KEY")) retrieve $client_secret
 
   $body_string = "grant_type=client_credentials&resource=https://management.core.windows.net/&client_id="+$client_id+"&client_secret="+$client_secret
 
@@ -305,4 +305,27 @@ define get_access_token($param_azure_tenant_id) return $access_token do
   $auth_response_body = $auth_response["body"]
   $access_token = $auth_response_body["access_token"]
 
+end
+
+define url_encode($string) return $encoded_string do
+  $encoded_string = $string
+  $encoded_string = gsub($encoded_string, " ", "%20")
+  $encoded_string = gsub($encoded_string, "!", "%21")
+  $encoded_string = gsub($encoded_string, "#", "%23")
+  $encoded_string = gsub($encoded_string, "$", "%24")
+  $encoded_string = gsub($encoded_string, "&", "%26")
+  $encoded_string = gsub($encoded_string, "'", "%27")
+  $encoded_string = gsub($encoded_string, "(", "%28")
+  $encoded_string = gsub($encoded_string, ")", "%29")
+  $encoded_string = gsub($encoded_string, "*", "%2A")
+  $encoded_string = gsub($encoded_string, "+", "%2B")
+  $encoded_string = gsub($encoded_string, ",", "%2C")
+  $encoded_string = gsub($encoded_string, "/", "%2F")
+  $encoded_string = gsub($encoded_string, ":", "%3A")
+  $encoded_string = gsub($encoded_string, ";", "%3B")
+  $encoded_string = gsub($encoded_string, "=", "%3D")
+  $encoded_string = gsub($encoded_string, "?", "%3F")
+  $encoded_string = gsub($encoded_string, "@", "%40")
+  $encoded_string = gsub($encoded_string, "[", "%5B")
+  $encoded_string = gsub($encoded_string, "]", "%5D")
 end


### PR DESCRIPTION
### Description
For the Azure specific policies that have escalations that interact with the Azure API, auth may fail if the client secret includes characters that should be URL encoded.

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
