### PR TITLE
Cheaper Regions Remove tag_instance_name dimension

### DIFF
--- a/cost/cheaper_regions/CHANGELOG.md
+++ b/cost/cheaper_regions/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.5
+----
+- removed tag_instance_name
+
 v1.4
 ----
 - Adding in resource_id so it easy to find resource

--- a/cost/cheaper_regions/cheaper_regions.pt
+++ b/cost/cheaper_regions/cheaper_regions.pt
@@ -2,7 +2,7 @@ name "Cheaper Regions"
 rs_pt_ver 20180301
 type "policy"
 short_description "Specify which regions have cheaper alternatives by specifying the expensive region name and the cheaper region name for analysis. See the [README](https://github.com/rightscale/policy_templates/tree/master/cost/azure/cheaper_regions/) and [docs.rightscale.com/policies](http://docs.rightscale.com/policies/) to learn more."
-long_description "Version: 1.4"
+long_description "Version: 1.5"
 severity "medium"
 category "Cost"
 
@@ -177,7 +177,6 @@ script "js_new_costs_request", type: "javascript" do
         "region", 
         "resource_group",
         "resource_type",
-        "tag_instance_name",
         "billing_center_id",
         "service",
         "resource_id"


### PR DESCRIPTION
### Description
tag_instance_name dimension is unused and unnecessary. 

### Issues Resolved

[List any existing issues this PR resolves]

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] New functionality has been documented in CHANGELOG.MD
